### PR TITLE
chore(init): initialize project documentation with PRD and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# [PROJECT NAME] — Claude Code Instructions
+# FIRE Simulator — Claude Code Instructions
 
 This file is the source of truth for how work gets done on this project.
 Read it before every session. Rules are not suggestions.
@@ -18,11 +18,11 @@ Read it before every session. Rules are not suggestions.
 
 ## 1. Project Context
 
-- **What:** [one sentence]
-- **Spec:** [path — read before any feature work]
-- **Stack:** [language] / [framework] / [database] / [hosting]
-- **Phase:** [optional milestone tracker — delete if not used]
-- **Commands:** test=`X` lint=`Y` typecheck=`Z` build=`W`
+- **What:** Interactive financial simulation tool comparing retirement withdrawal strategies under historical and Monte Carlo market scenarios.
+- **Spec:** [PRD.md](PRD.md) — read before feature work
+- **Stack:** TypeScript / React / Node.js backend / (no database for MVP)
+- **Phase:** MVP: core simulation engine + UI for parameter control and metric display
+- **Commands:** test=`npm test` lint=`npm run lint` typecheck=`npm run type-check` build=`npm run build`
 
 ---
 
@@ -59,14 +59,17 @@ Violating any of these requires explicit written approval *before* the
 code is written.
 
 ### 3.1 Data access
-- [where DB queries live and where they don't]
-- [ORM/client conventions]
+- No database for MVP. Historical market data loaded at startup from bundled datasets.
+- All data transforms (simulation logic) live in `src/lib/simulation/` module.
 
 ### 3.2 External calls
-- [where they live, auth requirements, error contract]
+- None for MVP. All computations are local.
+- Future: consider external data sources for market data updates; define error boundaries before adding.
 
 ### 3.3 State
-- [client vs server boundary, state library policy]
+- Client state: simulation parameters and results cached in React context or Redux (TBD).
+- Server state: none (stateless API, if needed later).
+- Simulation results (trajectories, distributions) computed on-demand, not persisted.
 
 ### 3.4 Configuration
 - All env vars read from [config path]. `process.env` / `os.environ`
@@ -75,11 +78,11 @@ code is written.
 - No secrets, tokens, or keys in code, comments, or logs. Ever.
 
 ### 3.5 Data integrity
-- [delete policy, validation layer, migration policy]
+- MVP: no persistent data. Input validation at UI boundary (parameter ranges per PRD).
+- Simulation outputs are immutable after computation.
 
 ### 3.6 Schema and migrations
-- Any change to persistent schema requires a migration in the same PR.
-- Schema changes without migrations are rejected.
+- No database for MVP; not applicable.
 
 ### 3.7 Dependencies and lockfile
 - New dependencies require approval. Provide: name, version, justification,

--- a/PRD.md
+++ b/PRD.md
@@ -1,0 +1,227 @@
+Product Requirements Document (PRD)
+
+FIRE Withdrawal Simulation Platform
+
+⸻
+
+1. Product Overview
+
+This product is an interactive financial simulation tool that enables users to explore retirement outcomes under different withdrawal strategies using historically grounded and statistically modeled equity returns.
+
+Users can adjust key retirement parameters in real time and immediately observe how different withdrawal strategies perform across:
+
+* Historical market sequences (rolling periods)
+* Synthetic Monte Carlo simulations
+
+The system is designed to combine educational clarity with institutional-grade modeling rigor, enabling both intuitive exploration and analytically credible outputs.
+
+⸻
+
+2. Problem Statement
+
+Most FIRE calculators oversimplify retirement risk by:
+
+* Assuming constant returns or single-path projections
+* Ignoring sequence-of-returns risk in a structured way
+* Providing opaque or non-comparable withdrawal strategies
+
+Users lack a tool that:
+
+* Compares robust withdrawal strategies under realistic market behavior
+* Separates historical truth from probabilistic simulation
+* Provides intuitive, real-time feedback on retirement sustainability
+
+⸻
+
+3. Goals
+
+Primary Goals
+
+* Allow users to simulate retirement outcomes under multiple validated withdrawal strategies
+* Quantify sustainability of retirement portfolios under real historical market sequences
+* Provide clear comparison between historical and Monte Carlo-based outcomes
+* Enable real-time interaction with parameters (within computational constraints)
+
+Secondary Goals
+
+* Educate users on tradeoffs between withdrawal strategies
+* Visualize sequence-of-returns risk intuitively
+* Encourage financially responsible withdrawal behavior grounded in established research
+
+⸻
+
+4. Non-Goals
+
+* No tax modeling
+* No alternative asset classes beyond equities (initially 100% equity portfolios only, with US/international split)
+* No user-defined arbitrary or experimental withdrawal strategies
+* No intraday or high-frequency modeling
+* No mobile optimization
+
+⸻
+
+5. Core User Experience
+
+Users interact with:
+
+A. Parameter Controls
+
+* Initial retirement portfolio value
+* Equity allocation:
+    * US equities %
+    * International equities %
+* Retirement horizon (e.g. 30–70 years)
+* Withdrawal strategy selection
+* Strategy-specific parameters (e.g. withdrawal rate, guardrail thresholds)
+
+All inputs are continuous where appropriate and designed for rapid scenario exploration.
+
+⸻
+
+B. Withdrawal Strategies (Supported Set)
+
+Only academically or advisor-established strategies are included:
+
+1. Fixed Real Withdrawal
+    * Constant inflation-adjusted withdrawal amount
+2. Fixed Percentage Withdrawal
+    * Constant percentage of portfolio value annually
+3. Guyton-Klinger Guardrails Strategy
+    * Dynamic adjustment based on portfolio performance bands
+    * Includes:
+        * withdrawal increase rule
+        * withdrawal cut rule
+        * inflation adjustment logic
+4. Inflation-Adjusted Hybrid Baseline Strategy
+    * Conservative hybrid between fixed real and percentage-based approaches
+
+Each strategy is deterministic and fully reproducible.
+
+⸻
+
+C. Simulation Modes
+
+Each user configuration produces two independent simulation outputs:
+
+1. Historical Backtest Mode
+
+* Uses rolling historical market sequences
+* Based on monthly return data aggregated into annual withdrawal cycles
+* Evaluates every valid retirement start period in dataset
+
+Outputs:
+
+* Survival rate (portfolio remains > 0 at horizon)
+* Distribution of ending portfolio values
+* Distribution of annual withdrawals over time
+
+⸻
+
+2. Monte Carlo Mode
+
+* Uses synthetic return generation calibrated to historical data characteristics
+* Preserves volatility clustering and return distribution properties at a high level
+* Produces large-sample probabilistic outcomes
+
+Outputs:
+
+* Survival probability distribution
+* Expected and percentile outcomes for ending wealth
+* Variance of withdrawal paths
+
+⸻
+
+6. Output Metrics
+
+All outputs are shown as aggregated distributions, not single-point estimates.
+
+Primary Metrics
+
+* Survival Rate
+    * Probability portfolio remains positive at end of horizon
+* Ending Portfolio Value
+    * Mean, median, variance, percentiles
+* Withdrawal Behavior
+    * Mean annual withdrawal (real dollars)
+    * Median withdrawal
+    * Variance over time
+
+⸻
+
+Secondary Metrics
+
+* Maximum drawdown across retirement period
+* Worst-case historical sequence performance
+* Failure year distribution (if depletion occurs)
+
+⸻
+
+7. Visualization Requirements
+
+The interface must support:
+
+* Real-time updating summary metrics
+* Time-series visualization of portfolio trajectories
+* Distribution views for:
+    * ending wealth
+    * survival outcomes
+* Side-by-side comparison between:
+    * historical vs Monte Carlo outputs
+
+Visualizations must emphasize:
+
+* distribution over certainty
+* risk variability across time sequences
+* sensitivity to parameter changes
+
+⸻
+
+8. Data Requirements
+
+* Monthly historical return data for:
+    * US equities
+    * International equities
+* Inflation index for real-return normalization
+
+All simulation outputs must be expressed in real (inflation-adjusted) terms, unless explicitly overridden by strategy logic.
+
+Annual aggregation is used only for visualization and reporting layers; simulation operates at monthly granularity.
+
+⸻
+
+9. System Behavior Requirements
+
+* Start-of-year withdrawal assumption for all simulations
+* Deterministic execution for identical inputs
+* Separation of:
+    * historical deterministic outcomes
+    * probabilistic Monte Carlo outcomes
+* Consistent inflation adjustment across all strategies
+
+⸻
+
+10. Performance Expectations
+
+* Parameter changes should trigger updated results in near real time where feasible
+* If real-time response is not achievable:
+    * correctness and completeness of simulation outputs take priority
+* System should degrade gracefully under computational load (e.g., by simplifying update frequency rather than reducing model fidelity)
+
+⸻
+
+11. Success Metrics
+
+* Users can clearly distinguish between strategies based on survival rate differences
+* Users can understand how parameter changes affect long-term outcomes within seconds
+* Historical vs Monte Carlo divergence is interpretable, not confusing
+* Users can identify withdrawal strategies that dominate others under most conditions
+
+⸻
+
+12. Key Design Principles
+
+* Truth over simplicity: do not oversimplify financial risk
+* Comparability over isolation: all strategies must be directly comparable
+* Distribution over point estimates: always show uncertainty
+* Historical grounding first: Monte Carlo is secondary validation, not primary truth
+* Deterministic strategies only: no probabilistic user-defined behaviors


### PR DESCRIPTION
## What
Initialize project documentation with the Product Requirements Document and project-specific Claude Code instructions. This establishes the spec and workflow rules for all future development on FIRE Simulator.

## Changes
- `PRD.md` — Complete product specification for FIRE withdrawal simulation platform
- `CLAUDE.md` — Updated with project context (stack, commands, data access patterns, state management)

## How to test
- Verify PRD.md is readable and contains withdrawal strategy specifications
- Confirm CLAUDE.md has project-specific sections filled in

## Manual steps
- None

## Test results
- No tests required for documentation setup

## Checklist
- [x] No secrets or env vars in code
- [x] No AI attribution in commits or metadata
- [x] PR title follows Conventional Commits