### PR TITLE
docs: add Linear issue branch naming guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,11 @@ git checkout -b {type}/{scope}-{description}
   Commits: `{type}({scope}): {imperative description, ≤72 chars}`
 - Types: `feat` `fix` `chore` `test` `docs` `refactor` `perf`
 
+### Branch naming for Linear issues
+When starting work on a Linear issue (e.g., J-12), **include the issue ID in the branch name**:
+- Recommended: `feat/J-12-short-description` or `J-12/short-description`
+- Avoid: `feat/short-description` (Linear won't auto-link)
+
 ### Before every commit
 Verify `git status` shows only intentional changes. No `.env`, no
 build artifacts, no `node_modules`. Stage explicitly when in doubt.


### PR DESCRIPTION
## What
Add guidance for branch naming when working on Linear issues, ensuring branch names include the Linear issue ID for auto-linking.

## Changes
- `CLAUDE.md` — added new subsection under Section 5 (Git Protocol) with Linear issue branch naming conventions

## How to test
N/A — documentation only

## Manual steps
None

## Test results
N/A

## Out of scope
None

## Checklist
- [x] No secrets or env vars in code
- [x] No debug statements committed
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commits or metadata