### PR TITLE
chore(ci): test against latest LTS Node.js only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## What
Simplify CI test matrix to single Node.js version (22.x), the current LTS. Removes redundant Node 20.x testing.

## Rationale
- Node 22.x is the latest LTS (expires April 2028)
- Node 20.x is still supported but nearing end of LTS (expires April 2027)
- No production requirement specified for Node 20 support
- Testing multiple LTS versions adds CI overhead without added safety for MVP
- Standard practice: test against latest LTS unless explicitly supporting older versions

## Changes
- `.github/workflows/ci.yml` — simplified matrix from [20.x, 22.x] to [22.x]

## How to test
CI will run lint, type-check, test, and build against Node 22.x only.

## Out of scope
Future: add package.json `engines` field if specific Node version support is required.

## Checklist
- [x] No secrets or env vars in code
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commits or metadata