### PR TITLE
feat(strategies): four withdrawal strategies + replace fixed-real with RMD

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -82,18 +82,21 @@ B. Withdrawal Strategies (Supported Set)
 
 Only academically or advisor-established strategies are included:
 
-1. Fixed Real Withdrawal
-    * Constant inflation-adjusted withdrawal amount
+1. RMD / Life-Expectancy-Based Withdrawal
+    * Annual withdrawal = real portfolio balance / remaining horizon years,
+      converted to nominal dollars
+    * Draws down the portfolio in proportion to remaining life expectancy
 2. Fixed Percentage Withdrawal
     * Constant percentage of portfolio value annually
 3. Guyton-Klinger Guardrails Strategy
     * Dynamic adjustment based on portfolio performance bands
     * Includes:
-        * withdrawal increase rule
-        * withdrawal cut rule
-        * inflation adjustment logic
+        * withdrawal increase rule (prosperity rule: +10% when WR 20% below initial)
+        * withdrawal cut rule (capital-preservation rule: −10% when WR 20% above initial)
+        * inflation adjustment logic (freeze after a down year when WR exceeds initial)
 4. Inflation-Adjusted Hybrid Baseline Strategy
-    * Conservative hybrid between fixed real and percentage-based approaches
+    * Percentage-of-balance withdrawal clamped to an inflation-adjusted
+      floor (−20% of initial real) and ceiling (+25% of initial real)
 
 Each strategy is deterministic and fully reproducible.
 

--- a/docs/decisions/0003-simulation-conventions.md
+++ b/docs/decisions/0003-simulation-conventions.md
@@ -20,7 +20,7 @@ The five conventions below cover withdrawal timing, inflation normalization, ret
 
 **Alternatives considered:**
 - *Start-of-year lump sum:* PRD §9 originally stated "start-of-year withdrawal assumption." This is the convention in classic FIRE research (Bengen 1994, Trinity Study). However, a monthly deduction is arithmetically cleaner — no single-month portfolio shock, and the balance at any month-end is immediately interpretable as "current portfolio value."
-- *Callback fires monthly:* All four supported strategies (Fixed Real, Fixed %, Guyton-Klinger, Hybrid Baseline) make annual decisions. Firing monthly would require strategies to carry state across 12 calls, adding complexity with no benefit.
+- *Callback fires monthly:* All four supported strategies (RMD/Life-Expectancy, Fixed %, Guyton-Klinger, Hybrid Baseline) make annual decisions. Firing monthly would require strategies to carry state across 12 calls, adding complexity with no benefit.
 
 **Rationale:** Monthly deduction gives strategies the annual decision cadence they are designed for, while producing a smooth monthly trajectory. The annual aggregate (`sum of 12 monthly deductions`) equals the strategy's declared withdrawal, making per-year reporting exact. PRD §9 is updated to reflect this refinement.
 

--- a/docs/decisions/0004-withdrawal-strategy-defaults.md
+++ b/docs/decisions/0004-withdrawal-strategy-defaults.md
@@ -1,0 +1,89 @@
+# 0004 — Withdrawal Strategy Defaults and Formulations
+
+**Date:** 2026-05-02
+**Status:** Accepted
+**Deciders:** Jacob Wu
+
+---
+
+## Context
+
+Four withdrawal strategies are required by PRD §5B. Three of them (Fixed Percentage, Guyton-Klinger, Hybrid Baseline) have numeric defaults that cannot be derived from first principles alone — they come from specific academic sources or are reasonable simplifications that must be pinned. RMD uses a formulation choice that warrants documentation.
+
+This ADR records the defaults and their sources so they are not changed incidentally.
+
+---
+
+## Strategy 1 — RMD / Life-Expectancy-Based Withdrawal
+
+**Formulation:** At the start of year `y`, withdraw `realBalance / remainingYears` expressed in nominal dollars.
+
+```
+remainingYears = horizonYears - yearIndex          (minimum 1)
+realAnnualAmount = state.realBalance / remainingYears
+nominalAmount = realAnnualAmount * state.cumulativeInflation
+```
+
+**Alternative considered:** IRS Uniform Lifetime Table divisors (Publication 590-B). The table starts at age 73 (current law) and requires a `startAge` parameter that no other strategy needs. For MVP, a generalized divisor (`1 / remainingYears`) captures the life-expectancy mechanic cleanly without binding to IRS age thresholds or adding a strategy-specific input to the UI parameter surface. An age-parameterized variant can be introduced later without breaking this one.
+
+**Why "remaining years of horizon" rather than a static table:** Makes the strategy self-consistent for any horizon (30-year, 40-year, 60-year) and keeps the parameter surface identical to the other strategies.
+
+---
+
+## Strategy 2 — Fixed Percentage Withdrawal
+
+**Default rate:** `4.0 %` per year of nominal portfolio value.
+
+**Source:** Bengen (1994) "Determining Withdrawal Rates Using Historical Data," JAEFP — the original "4% rule" paper. This is the conventional starting point for fixed-percentage FIRE planning.
+
+**Note:** The factory exposes `rate` as a required param, so callers always pass it explicitly. The 4% default is used only in the strategy-params default object (the registry / UI layer), not hard-coded in the strategy itself.
+
+---
+
+## Strategy 3 — Guyton-Klinger Guardrails
+
+**Source:** Guyton & Klinger (2006) "Decision Rules and Maximum Initial Withdrawal Rates," Journal of Financial Planning.
+
+| Parameter | Value | Rule name in paper |
+|---|---|---|
+| Initial withdrawal rate | `4.0 %` of initial portfolio | — |
+| Prosperity-rule threshold | `+20 %` below initial WR | "Prosperity Rule" |
+| Prosperity-rule increase | `+10 %` of current withdrawal | "Prosperity Rule" |
+| Capital-preservation threshold | `+20 %` above initial WR | "Capital Preservation Rule" |
+| Capital-preservation cut | `−10 %` of current withdrawal | "Capital Preservation Rule" |
+| Inflation freeze condition | WR > initial WR **and** prior year had a negative real return | "Inflation Adjustment Rule" |
+
+**"Down year" detection in this engine:** The strategy factory compares the year-start `realBalance` to the prior year-start `realBalance`. If real balance declined year-over-year, the year is considered a down year for the inflation-freeze rule. This is a reasonable proxy for "portfolio performance" given the engine only exposes start-of-year state.
+
+**Initial withdrawal rate note:** The factory accepts `initialRate` as a required param (default `0.04`). `initialNominalWithdrawal = initialPortfolio * initialRate`. Subsequent years apply the guard-band rules against the evolving current withdrawal rate (`currentWithdrawal / currentNominalBalance`).
+
+---
+
+## Strategy 4 — Inflation-Adjusted Hybrid Baseline
+
+**Formulation:** Each year, withdraw `pct * nominalBalance`, clamped to an inflation-adjusted floor and ceiling derived from the initial real withdrawal level.
+
+```
+unconstrained = pct * state.nominalBalance
+floor         = initialRealWithdrawal * floorMultiplier * state.cumulativeInflation
+ceiling       = initialRealWithdrawal * ceilingMultiplier * state.cumulativeInflation
+nominalAmount = clamp(unconstrained, floor, ceiling)
+```
+
+where `initialRealWithdrawal = initialPortfolio * pct / cumulativeInflation_at_year_0` (= `initialPortfolio * pct` since year-0 cumInfl = 1).
+
+| Parameter | Default | Rationale |
+|---|---|---|
+| `pct` | `0.04` | Same 4% anchor as other strategies for comparability |
+| `floorMultiplier` | `0.80` | Retiree never takes more than a 20% real cut from baseline |
+| `ceilingMultiplier` | `1.25` | Retiree never takes more than a 25% real increase from baseline |
+
+**Why this formulation:** Combines the sequence-of-returns responsiveness of a percentage strategy (balance drops → withdrawal drops) with the spending stability of a fixed-real approach (floor/ceiling prevent extreme cuts or windfalls). The floor/ceiling are indexed to the initial real withdrawal, not to nominal dollars, so they inflate with the rest of the economy.
+
+---
+
+## Consequences
+
+- These defaults must not change without a new ADR entry or an amendment here, as they affect baseline behavior visible to users in future UI.
+- Strategy factories accept all numeric parameters explicitly so these defaults live only in one place (the registry's default-params map, introduced in a later PR).
+- If IRS-table RMD becomes a requirement, it is added as a separate strategy (`"rmd-irs"`) rather than modifying this one.

--- a/src/lib/strategies/fixed-percentage.test.ts
+++ b/src/lib/strategies/fixed-percentage.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { createFixedPct } from './fixed-percentage';
+import type { MonthState } from '../simulation/types';
+
+function makeState(overrides: Partial<MonthState> = {}): MonthState {
+  return {
+    monthIndex: 0,
+    yearIndex: 0,
+    monthOfYear: 0,
+    nominalBalance: 1_000_000,
+    realBalance: 1_000_000,
+    cumulativeInflation: 1,
+    ...overrides,
+  };
+}
+
+describe('createFixedPct', () => {
+  it('withdraws rate * nominalBalance each year', () => {
+    const fn = createFixedPct({ id: 'fixedPct', rate: 0.04 });
+    const state = makeState({ nominalBalance: 800_000 });
+    expect(fn(state).nominalAmount).toBeCloseTo(32_000, 6);
+  });
+
+  it('withdrawal scales correctly with a different rate', () => {
+    const fn = createFixedPct({ id: 'fixedPct', rate: 0.035 });
+    const state = makeState({ nominalBalance: 1_200_000 });
+    expect(fn(state).nominalAmount).toBeCloseTo(42_000, 6);
+  });
+
+  it('withdraws 0 when portfolio is depleted', () => {
+    const fn = createFixedPct({ id: 'fixedPct', rate: 0.04 });
+    const state = makeState({ nominalBalance: 0 });
+    expect(fn(state).nominalAmount).toBe(0);
+  });
+
+  it('is deterministic — identical inputs produce identical output', () => {
+    const fn = createFixedPct({ id: 'fixedPct', rate: 0.05 });
+    const state = makeState({ nominalBalance: 650_000 });
+    expect(fn(state).nominalAmount).toBe(fn(state).nominalAmount);
+  });
+});

--- a/src/lib/strategies/fixed-percentage.ts
+++ b/src/lib/strategies/fixed-percentage.ts
@@ -1,0 +1,13 @@
+import type { FixedPctParams, StrategyFactory } from './types';
+
+/**
+ * Fixed Percentage Withdrawal (see ADR 0004).
+ *
+ * Each year: withdraw rate * nominalBalance.
+ */
+export const createFixedPct: StrategyFactory<FixedPctParams> = ({ rate }) => {
+  return (state) => {
+    if (state.nominalBalance <= 0) return { nominalAmount: 0 };
+    return { nominalAmount: rate * state.nominalBalance };
+  };
+};

--- a/src/lib/strategies/guyton-klinger.test.ts
+++ b/src/lib/strategies/guyton-klinger.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { createGk } from './guyton-klinger';
+import type { MonthState } from '../simulation/types';
+
+function makeState(overrides: Partial<MonthState> = {}): MonthState {
+  return {
+    monthIndex: 0,
+    yearIndex: 0,
+    monthOfYear: 0,
+    nominalBalance: 1_000_000,
+    realBalance: 1_000_000,
+    cumulativeInflation: 1,
+    ...overrides,
+  };
+}
+
+const BASE_PARAMS = { id: 'gk' as const, initialPortfolio: 1_000_000, initialRate: 0.04 };
+
+describe('createGk', () => {
+  describe('year 0 (first year)', () => {
+    it('withdraws initialPortfolio * initialRate in year 0', () => {
+      const fn = createGk(BASE_PARAMS);
+      const result = fn(makeState({ yearIndex: 0, nominalBalance: 1_000_000 }));
+      expect(result.nominalAmount).toBeCloseTo(40_000, 6);
+    });
+  });
+
+  describe('prosperity rule', () => {
+    it('raises withdrawal by 10% when current WR is 20%+ below initial', () => {
+      const fn = createGk(BASE_PARAMS);
+      // Year 0: baseline withdrawal = 40_000, cumInflation = 1
+      fn(makeState({ yearIndex: 0, nominalBalance: 1_000_000, realBalance: 1_000_000, cumulativeInflation: 1 }));
+
+      // Year 1: zero inflation (cumInflation stays 1) so the CPI bump is 0 and only the
+      // prosperity rule fires. Portfolio has grown → WR = 40_000 / 2_000_000 = 2% < 4% initial;
+      // wrRatio = 0.5 < 0.8 → prosperity rule: +10%.
+      const result = fn(
+        makeState({
+          yearIndex: 1,
+          nominalBalance: 2_000_000,
+          realBalance: 2_000_000,
+          cumulativeInflation: 1,
+        }),
+      );
+      expect(result.nominalAmount).toBeCloseTo(40_000 * 1.1, 6);
+    });
+  });
+
+  describe('capital-preservation rule', () => {
+    it('cuts withdrawal by 10% when current WR is 20%+ above initial', () => {
+      const fn = createGk(BASE_PARAMS);
+      // Year 0
+      fn(makeState({ yearIndex: 0, nominalBalance: 1_000_000, realBalance: 1_000_000 }));
+
+      // Year 1: portfolio has dropped significantly → current WR = 40_000 / 400_000 = 10% (initial=4%)
+      // wrRatio = 2.5, which is > 1.2 (1 + 0.2 guard band) → preservation rule fires
+      const result = fn(
+        makeState({
+          yearIndex: 1,
+          nominalBalance: 400_000,
+          realBalance: 360_000,
+          cumulativeInflation: 1.11,
+        }),
+      );
+      expect(result.nominalAmount).toBeCloseTo(40_000 * 0.9, 6);
+    });
+  });
+
+  describe('inflation freeze rule', () => {
+    it('skips the CPI bump when it is a down year and WR exceeds initial rate', () => {
+      const fn = createGk(BASE_PARAMS);
+      // Year 0: baseline withdrawal = 40_000, cumInflation = 1
+      fn(makeState({ yearIndex: 0, nominalBalance: 1_000_000, realBalance: 1_000_000, cumulativeInflation: 1 }));
+
+      // Year 1: portfolio slightly down in real terms; WR slightly above initial;
+      // balance is close enough to initial that guard bands do NOT fire (wrRatio ≈ 1.05),
+      // but inflation would normally increase withdrawal by 3%.
+      // cumInflation = 1.03 → annual inflation = 3%
+      // currentWR = 40_000 / 950_000 ≈ 4.21% > 4% → inflationFrozen (down year + WR > initial)
+      // Guard band check: wrRatio = 4.21%/4% = 1.05, inside ±20% band → no rule fires
+      // Expected: withdrawal stays at 40_000 (no CPI bump, no guard-band adjustment)
+      const result = fn(
+        makeState({
+          yearIndex: 1,
+          nominalBalance: 950_000,
+          realBalance: 920_000, // down from 1_000_000 → down year
+          cumulativeInflation: 1.03,
+        }),
+      );
+      expect(result.nominalAmount).toBeCloseTo(40_000, 6);
+    });
+
+    it('applies the CPI bump normally when it is NOT a down year', () => {
+      const fn = createGk(BASE_PARAMS);
+      // Year 0
+      fn(makeState({ yearIndex: 0, nominalBalance: 1_000_000, realBalance: 1_000_000, cumulativeInflation: 1 }));
+
+      // Year 1: portfolio UP in real terms; cumInflation = 1.03 → 3% annual inflation applied
+      // nominalBalance = 1_000_000 → currentWR ≈ 4% (inside guard bands, no rule fires)
+      // Expected: 40_000 * 1.03 = 41_200
+      const result = fn(
+        makeState({
+          yearIndex: 1,
+          nominalBalance: 1_000_000,
+          realBalance: 1_050_000, // UP year
+          cumulativeInflation: 1.03,
+        }),
+      );
+      expect(result.nominalAmount).toBeCloseTo(40_000 * 1.03, 6);
+    });
+  });
+
+  describe('boundary conditions', () => {
+    it('returns 0 when portfolio is depleted', () => {
+      const fn = createGk(BASE_PARAMS);
+      expect(fn(makeState({ nominalBalance: 0, realBalance: 0 })).nominalAmount).toBe(0);
+    });
+  });
+
+  describe('determinism', () => {
+    it('produces identical results when called with identical inputs from identical state', () => {
+      const fn1 = createGk(BASE_PARAMS);
+      const fn2 = createGk(BASE_PARAMS);
+      const s0 = makeState({ yearIndex: 0, nominalBalance: 1_000_000, realBalance: 1_000_000 });
+      const s1 = makeState({
+        yearIndex: 1,
+        nominalBalance: 950_000,
+        realBalance: 880_000,
+        cumulativeInflation: 1.08,
+      });
+      // Advance both closures through year 0, then compare year 1
+      fn1(s0);
+      fn2(s0);
+      expect(fn1(s1).nominalAmount).toBe(fn2(s1).nominalAmount);
+    });
+  });
+});

--- a/src/lib/strategies/guyton-klinger.ts
+++ b/src/lib/strategies/guyton-klinger.ts
@@ -1,0 +1,69 @@
+import type { GkParams, StrategyFactory } from './types';
+
+/**
+ * Guyton-Klinger Guardrails Strategy (see ADR 0004).
+ *
+ * Three independent rules from Guyton & Klinger (2006):
+ *
+ * 1. Inflation Adjustment Rule: each year increase withdrawal by CPI.
+ *    Exception: skip the CPI bump when (portfolio was a down year AND WR > initial WR).
+ *
+ * 2. Prosperity Rule: if current WR falls 20%+ below initial WR → raise withdrawal by 10%.
+ *
+ * 3. Capital-Preservation Rule: if current WR rises 20%+ above initial WR → cut by 10%.
+ *
+ * Rules 2 and 3 are independent of rule 1 (they fire regardless of down-year status).
+ *
+ * "Down year" is detected by comparing this year's real balance to the prior year's
+ * real balance (see ADR 0004 for rationale).
+ *
+ * CPI between years is derived from prevCumInflation / currentCumInflation.
+ */
+export const createGk: StrategyFactory<GkParams> = ({
+  initialPortfolio,
+  initialRate,
+}) => {
+  const initialNominalWithdrawal = initialPortfolio * initialRate;
+  const GUARD_BAND = 0.2;
+  const PROSPERITY_INCREASE = 0.1;
+  const PRESERVATION_CUT = 0.1;
+
+  let currentWithdrawal = initialNominalWithdrawal;
+  let prevYearRealBalance: number | null = null;
+  let prevCumInflation = 1;
+
+  return (state) => {
+    if (state.nominalBalance <= 0) return { nominalAmount: 0 };
+
+    const isFirstYear = state.yearIndex === 0;
+
+    if (!isFirstYear) {
+      // --- Rule 1: Inflation Adjustment ---
+      const wasDownYear =
+        prevYearRealBalance !== null && state.realBalance < prevYearRealBalance;
+
+      const priorWR = currentWithdrawal / (state.nominalBalance);
+      const inflationFrozen = wasDownYear && priorWR > initialRate;
+
+      if (!inflationFrozen && prevCumInflation > 0) {
+        const annualInflation = state.cumulativeInflation / prevCumInflation - 1;
+        currentWithdrawal = currentWithdrawal * (1 + annualInflation);
+      }
+
+      // --- Rules 2 & 3: Guard bands (independent of inflation freeze) ---
+      const currentWR = currentWithdrawal / state.nominalBalance;
+      const wrRatio = currentWR / initialRate;
+
+      if (wrRatio < 1 - GUARD_BAND) {
+        currentWithdrawal = currentWithdrawal * (1 + PROSPERITY_INCREASE);
+      } else if (wrRatio > 1 + GUARD_BAND) {
+        currentWithdrawal = currentWithdrawal * (1 - PRESERVATION_CUT);
+      }
+    }
+
+    prevYearRealBalance = state.realBalance;
+    prevCumInflation = state.cumulativeInflation;
+
+    return { nominalAmount: currentWithdrawal };
+  };
+};

--- a/src/lib/strategies/hybrid.test.ts
+++ b/src/lib/strategies/hybrid.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { createHybrid } from './hybrid';
+import type { MonthState } from '../simulation/types';
+
+function makeState(overrides: Partial<MonthState> = {}): MonthState {
+  return {
+    monthIndex: 0,
+    yearIndex: 0,
+    monthOfYear: 0,
+    nominalBalance: 1_000_000,
+    realBalance: 1_000_000,
+    cumulativeInflation: 1,
+    ...overrides,
+  };
+}
+
+const BASE_PARAMS = {
+  id: 'hybrid' as const,
+  initialPortfolio: 1_000_000,
+  rate: 0.04,
+  floorMultiplier: 0.8,
+  ceilingMultiplier: 1.25,
+};
+
+// initialRealWithdrawal = 1_000_000 * 0.04 = 40_000
+
+describe('createHybrid', () => {
+  describe('unconstrained mid-band withdrawal', () => {
+    it('returns rate * nominalBalance when inside floor and ceiling', () => {
+      const fn = createHybrid(BASE_PARAMS);
+      // cumInfl=1 → floor=32_000, ceiling=50_000; unconstrained=0.04*900_000=36_000 (inside band)
+      const state = makeState({ nominalBalance: 900_000, cumulativeInflation: 1 });
+      expect(fn(state).nominalAmount).toBeCloseTo(36_000, 6);
+    });
+  });
+
+  describe('floor clamping', () => {
+    it('clamps to floor when unconstrained falls below floorMultiplier * initialReal * cumInflation', () => {
+      const fn = createHybrid(BASE_PARAMS);
+      // cumInfl=1.2 → floor = 40_000 * 0.8 * 1.2 = 38_400
+      // balance=600_000 → unconstrained = 0.04 * 600_000 = 24_000 (below floor)
+      const state = makeState({ nominalBalance: 600_000, cumulativeInflation: 1.2 });
+      expect(fn(state).nominalAmount).toBeCloseTo(38_400, 6);
+    });
+  });
+
+  describe('ceiling clamping', () => {
+    it('clamps to ceiling when unconstrained rises above ceilingMultiplier * initialReal * cumInflation', () => {
+      const fn = createHybrid(BASE_PARAMS);
+      // cumInfl=1.1 → ceiling = 40_000 * 1.25 * 1.1 = 55_000
+      // balance=2_000_000 → unconstrained = 0.04 * 2_000_000 = 80_000 (above ceiling)
+      const state = makeState({ nominalBalance: 2_000_000, cumulativeInflation: 1.1 });
+      expect(fn(state).nominalAmount).toBeCloseTo(55_000, 6);
+    });
+  });
+
+  describe('boundary conditions', () => {
+    it('returns 0 when portfolio is depleted', () => {
+      const fn = createHybrid(BASE_PARAMS);
+      expect(fn(makeState({ nominalBalance: 0 })).nominalAmount).toBe(0);
+    });
+  });
+
+  describe('determinism', () => {
+    it('produces identical results for identical inputs', () => {
+      const fn = createHybrid(BASE_PARAMS);
+      const state = makeState({ nominalBalance: 850_000, cumulativeInflation: 1.15 });
+      expect(fn(state).nominalAmount).toBe(fn(state).nominalAmount);
+    });
+  });
+});

--- a/src/lib/strategies/hybrid.ts
+++ b/src/lib/strategies/hybrid.ts
@@ -1,0 +1,32 @@
+import type { HybridParams, StrategyFactory } from './types';
+
+/**
+ * Inflation-Adjusted Hybrid Baseline Strategy (see ADR 0004).
+ *
+ * Withdraws rate * nominalBalance, clamped to an inflation-adjusted
+ * floor and ceiling derived from the initial real withdrawal:
+ *
+ *   unconstrained = rate * nominalBalance
+ *   floor         = initialRealWithdrawal * floorMultiplier * cumulativeInflation
+ *   ceiling       = initialRealWithdrawal * ceilingMultiplier * cumulativeInflation
+ *   nominalAmount = clamp(unconstrained, floor, ceiling)
+ */
+export const createHybrid: StrategyFactory<HybridParams> = ({
+  initialPortfolio,
+  rate,
+  floorMultiplier,
+  ceilingMultiplier,
+}) => {
+  // At year 0, cumulativeInflation = 1, so initialRealWithdrawal = initialPortfolio * rate.
+  const initialRealWithdrawal = initialPortfolio * rate;
+
+  return (state) => {
+    if (state.nominalBalance <= 0) return { nominalAmount: 0 };
+
+    const unconstrained = rate * state.nominalBalance;
+    const floor = initialRealWithdrawal * floorMultiplier * state.cumulativeInflation;
+    const ceiling = initialRealWithdrawal * ceilingMultiplier * state.cumulativeInflation;
+
+    return { nominalAmount: Math.min(ceiling, Math.max(floor, unconstrained)) };
+  };
+};

--- a/src/lib/strategies/index.ts
+++ b/src/lib/strategies/index.ts
@@ -1,0 +1,33 @@
+export type { StrategyId, StrategyParams, WithdrawalFn, StrategyFactory } from './types';
+export type { RmdParams } from './types';
+export type { FixedPctParams } from './types';
+export type { GkParams } from './types';
+export type { HybridParams } from './types';
+
+export { createRmd } from './rmd';
+export { createFixedPct } from './fixed-percentage';
+export { createGk } from './guyton-klinger';
+export { createHybrid } from './hybrid';
+
+import type { StrategyParams, WithdrawalFn } from './types';
+import { createRmd } from './rmd';
+import { createFixedPct } from './fixed-percentage';
+import { createGk } from './guyton-klinger';
+import { createHybrid } from './hybrid';
+
+/**
+ * Creates a withdrawalFn from a typed StrategyParams object.
+ * This is the single dispatch point for the engine to obtain a strategy callback.
+ */
+export function createStrategy(params: StrategyParams): WithdrawalFn {
+  switch (params.id) {
+    case 'rmd':
+      return createRmd(params);
+    case 'fixedPct':
+      return createFixedPct(params);
+    case 'gk':
+      return createGk(params);
+    case 'hybrid':
+      return createHybrid(params);
+  }
+}

--- a/src/lib/strategies/rmd.test.ts
+++ b/src/lib/strategies/rmd.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { createRmd } from './rmd';
+import type { MonthState } from '../simulation/types';
+
+function makeState(overrides: Partial<MonthState> = {}): MonthState {
+  return {
+    monthIndex: 0,
+    yearIndex: 0,
+    monthOfYear: 0,
+    nominalBalance: 1_000_000,
+    realBalance: 1_000_000,
+    cumulativeInflation: 1,
+    ...overrides,
+  };
+}
+
+describe('createRmd', () => {
+  it('withdraws realBalance divided by remaining years in nominal terms (year 0)', () => {
+    const fn = createRmd({ id: 'rmd', horizonYears: 30 });
+    const state = makeState({
+      yearIndex: 0,
+      nominalBalance: 900_000,
+      realBalance: 800_000,
+      cumulativeInflation: 1.125,
+    });
+    // remainingYears = 30 - 0 = 30
+    // realAnnual = 800_000 / 30
+    // nominalAmount = (800_000 / 30) * 1.125
+    const expected = (800_000 / 30) * 1.125;
+    expect(fn(state).nominalAmount).toBeCloseTo(expected, 6);
+  });
+
+  it('withdraws realBalance divided by remaining years mid-horizon', () => {
+    const fn = createRmd({ id: 'rmd', horizonYears: 30 });
+    const state = makeState({
+      yearIndex: 10,
+      nominalBalance: 700_000,
+      realBalance: 600_000,
+      cumulativeInflation: 1.3,
+    });
+    // remainingYears = 30 - 10 = 20
+    const expected = (600_000 / 20) * 1.3;
+    expect(fn(state).nominalAmount).toBeCloseTo(expected, 6);
+  });
+
+  it('uses remainingYears of 1 on the final year to avoid division by zero', () => {
+    const fn = createRmd({ id: 'rmd', horizonYears: 30 });
+    const state = makeState({
+      yearIndex: 30,
+      nominalBalance: 50_000,
+      realBalance: 40_000,
+      cumulativeInflation: 1.5,
+    });
+    // remainingYears = max(1, 30 - 30) = 1
+    const expected = (40_000 / 1) * 1.5;
+    expect(fn(state).nominalAmount).toBeCloseTo(expected, 6);
+  });
+
+  it('returns 0 when portfolio is depleted', () => {
+    const fn = createRmd({ id: 'rmd', horizonYears: 30 });
+    const state = makeState({ nominalBalance: 0, realBalance: 0 });
+    expect(fn(state).nominalAmount).toBe(0);
+  });
+
+  it('is deterministic — identical inputs produce identical output', () => {
+    const fn = createRmd({ id: 'rmd', horizonYears: 40 });
+    const state = makeState({
+      yearIndex: 5,
+      nominalBalance: 850_000,
+      realBalance: 720_000,
+      cumulativeInflation: 1.18,
+    });
+    expect(fn(state).nominalAmount).toBe(fn(state).nominalAmount);
+  });
+});

--- a/src/lib/strategies/rmd.ts
+++ b/src/lib/strategies/rmd.ts
@@ -1,0 +1,16 @@
+import type { RmdParams, StrategyFactory } from './types';
+
+/**
+ * RMD / Life-Expectancy-Based Withdrawal (see ADR 0004).
+ *
+ * Each year: withdraw realBalance / remainingYears, converted to nominal.
+ * remainingYears = horizonYears - yearIndex (floored at 1).
+ */
+export const createRmd: StrategyFactory<RmdParams> = ({ horizonYears }) => {
+  return (state) => {
+    if (state.nominalBalance <= 0) return { nominalAmount: 0 };
+    const remainingYears = Math.max(1, horizonYears - state.yearIndex);
+    const realAnnual = state.realBalance / remainingYears;
+    return { nominalAmount: realAnnual * state.cumulativeInflation };
+  };
+};

--- a/src/lib/strategies/types.ts
+++ b/src/lib/strategies/types.ts
@@ -1,0 +1,60 @@
+import type { MonthState, WithdrawalDecision } from '../simulation/types';
+
+/** All supported withdrawal strategy identifiers. */
+export type StrategyId = 'rmd' | 'fixedPct' | 'gk' | 'hybrid';
+
+/** Parameters for the RMD / life-expectancy strategy. */
+export interface RmdParams {
+  id: 'rmd';
+  /** Total retirement horizon in years — must match SimParams.horizonYears. */
+  horizonYears: number;
+}
+
+/** Parameters for the fixed-percentage strategy. */
+export interface FixedPctParams {
+  id: 'fixedPct';
+  /** Annual withdrawal rate as a decimal (e.g. 0.04 for 4%). Must be > 0. */
+  rate: number;
+}
+
+/** Parameters for the Guyton-Klinger guardrails strategy. */
+export interface GkParams {
+  id: 'gk';
+  /** Initial portfolio value in nominal dollars (month-0). */
+  initialPortfolio: number;
+  /** Initial withdrawal rate as a decimal (e.g. 0.04). Must be > 0. */
+  initialRate: number;
+}
+
+/** Parameters for the inflation-adjusted hybrid baseline strategy. */
+export interface HybridParams {
+  id: 'hybrid';
+  /** Initial portfolio value in nominal dollars (month-0). */
+  initialPortfolio: number;
+  /**
+   * Base withdrawal rate applied to current balance each year.
+   * The unconstrained amount is clamped to floor/ceiling.
+   */
+  rate: number;
+  /**
+   * Floor multiplier relative to initial real withdrawal.
+   * Withdrawal will not fall below initialRealWithdrawal * floorMultiplier (in real terms).
+   * Default: 0.80.
+   */
+  floorMultiplier: number;
+  /**
+   * Ceiling multiplier relative to initial real withdrawal.
+   * Withdrawal will not rise above initialRealWithdrawal * ceilingMultiplier (in real terms).
+   * Default: 1.25.
+   */
+  ceilingMultiplier: number;
+}
+
+/** Discriminated union of all strategy parameter objects. */
+export type StrategyParams = RmdParams | FixedPctParams | GkParams | HybridParams;
+
+/** The engine callback signature that every strategy factory must return. */
+export type WithdrawalFn = (state: MonthState) => WithdrawalDecision;
+
+/** A strategy factory: given params, returns a closure bound to those params. */
+export type StrategyFactory<P extends StrategyParams> = (params: P) => WithdrawalFn;


### PR DESCRIPTION
## What
Implements the four PRD-mandated withdrawal strategies as pure factory functions (`(params) => withdrawalFn`) matching the engine's callback signature, and replaces Fixed Real Withdrawal with RMD / Life-Expectancy-Based Withdrawal per user direction. PRD §5B and ADR 0003 updated accordingly; ADR 0004 added to lock in formulation choices and numeric defaults.

## Changes
- `src/lib/strategies/types.ts` — `StrategyId`, `StrategyParams` discriminated union, `WithdrawalFn`, `StrategyFactory<P>` types
- `src/lib/strategies/rmd.ts` — withdraw `realBalance / remainingYears` (nominal), `remainingYears = max(1, horizonYears − yearIndex)`
- `src/lib/strategies/fixed-percentage.ts` — withdraw `rate × nominalBalance`
- `src/lib/strategies/guyton-klinger.ts` — CPI bump (frozen on down year + WR > initial); prosperity +10% / capital-preservation −10% guard bands (±20% of initial WR, independent of freeze)
- `src/lib/strategies/hybrid.ts` — `clamp(rate × balance, floor × cumInfl, ceiling × cumInfl)` relative to initial real withdrawal
- `src/lib/strategies/index.ts` — `createStrategy(params)` dispatcher + re-exports
- `docs/decisions/0004-withdrawal-strategy-defaults.md` — ADR for RMD divisor choice, GK defaults (Guyton & Klinger 2006), and Hybrid floor/ceiling values
- `PRD.md` §5B — strategy 1 replaced; descriptions tightened
- `docs/decisions/0003-simulation-conventions.md` — strategy list updated in Convention 1

## How to test
1. `npm test` — all 46 tests pass, including strategy-specific rule tests
2. `npm run type-check && npm run lint && npm run build` — all green
3. Inspect `createStrategy({ id: 'gk', initialPortfolio: 1_000_000, initialRate: 0.04 })` — returns a closure that applies GK rules year-by-year

## Manual steps
- None

## Test results
- All tests: 46 passing, 0 failing
- New tests: 22 (5 RMD, 4 fixed-pct, 7 GK, 5 hybrid, 1 sanity pre-existing)

## Out of scope
- UI wiring (strategy selector, parameter controls) — separate PR
- Monte Carlo / historical backtest wiring — separate PR
- IRS-table RMD (`"rmd-irs"` variant) — ADR 0004 notes this as a future addition

## Checklist
- [x] Tests / types / lint / build all green
- [x] No secrets or env vars in code
- [x] `.env.example` not applicable (no new env vars)
- [x] No debug statements committed
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commits or metadata
- [x] Schema changes not applicable (no DB)

Fixes J-14