### PR TITLE
feat(runners): historical backtest runner + aggregated outputs

### DIFF
--- a/src/lib/runners/historical.test.ts
+++ b/src/lib/runners/historical.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { runHistorical } from './historical';
+import type { SimParams } from '../simulation/types';
+import type { MarketDataset } from '../data/types';
+import type { StrategyParams } from '../strategies/types';
+
+function makeDataset(months: number, usReturn: number, intlReturn: number, inflation: number): MarketDataset {
+  const usEquity = Array.from({ length: months }, (_, i) => ({
+    date: `2000-${String((i % 12) + 1).padStart(2, '0')}`,
+    value: usReturn,
+  }));
+  const intlEquity = Array.from({ length: months }, (_, i) => ({
+    date: `2000-${String((i % 12) + 1).padStart(2, '0')}`,
+    value: intlReturn,
+  }));
+  const cpi = Array.from({ length: months }, (_, i) => ({
+    date: `2000-${String((i % 12) + 1).padStart(2, '0')}`,
+    value: inflation,
+  }));
+  return {
+    usEquity,
+    intlEquity,
+    cpi,
+    startDate: '2000-01',
+    endDate: '2000-01',
+  };
+}
+
+const BASE_PARAMS: SimParams = {
+  initialPortfolio: 1_000_000,
+  allocation: { us: 0.6, intl: 0.4 },
+  horizonYears: 30,
+};
+
+const FIXED_PCT_STRATEGY: StrategyParams = {
+  id: 'fixedPct',
+  rate: 0.04,
+};
+
+describe('runHistorical – period count', () => {
+  it('counts the correct number of rolling periods for a dataset with exactly one valid start', () => {
+    const horizonMonths = BASE_PARAMS.horizonYears * 12;
+    const dataset = makeDataset(horizonMonths, 0.005, 0.004, 0.002);
+    const result = runHistorical(BASE_PARAMS, dataset, FIXED_PCT_STRATEGY);
+    expect(result.periodCount).toBe(1);
+  });
+
+  it('counts N - horizonMonths + 1 rolling periods for a dataset with extra months', () => {
+    const horizonMonths = BASE_PARAMS.horizonYears * 12;
+    const extraMonths = 24;
+    const dataset = makeDataset(horizonMonths + extraMonths, 0.005, 0.004, 0.002);
+    const result = runHistorical(BASE_PARAMS, dataset, FIXED_PCT_STRATEGY);
+    expect(result.periodCount).toBe(extraMonths + 1);
+  });
+
+  it('returns zero periods when the dataset is shorter than the horizon', () => {
+    const horizonMonths = BASE_PARAMS.horizonYears * 12;
+    const dataset = makeDataset(horizonMonths - 1, 0.005, 0.004, 0.002);
+    const result = runHistorical(BASE_PARAMS, dataset, FIXED_PCT_STRATEGY);
+    expect(result.periodCount).toBe(0);
+    expect(result.survivalRate).toBe(0);
+  });
+});
+
+describe('runHistorical – survival rate', () => {
+  it('reports 100 % survival on a dataset with strongly positive returns', () => {
+    const horizonMonths = BASE_PARAMS.horizonYears * 12;
+    // ~1 % per month return, 2 % annual withdrawal → portfolio grows throughout
+    const dataset = makeDataset(horizonMonths + 12, 0.01, 0.01, 0.002);
+    const strategy: StrategyParams = { id: 'fixedPct', rate: 0.02 };
+    const result = runHistorical(BASE_PARAMS, dataset, strategy);
+    expect(result.survivalRate).toBe(1);
+    expect(result.trajectories.every((t) => t.survived)).toBe(true);
+  });
+
+  it('reports 0 % survival when using a GK strategy with an unsustainable 50 % initial rate', () => {
+    const horizonMonths = BASE_PARAMS.horizonYears * 12;
+    // Flat 0 % returns + 50 % annual withdrawal → depletes within a few years in every period
+    const dataset = makeDataset(horizonMonths + 12, 0.0, 0.0, 0.0);
+    const strategy: StrategyParams = {
+      id: 'gk',
+      initialPortfolio: BASE_PARAMS.initialPortfolio,
+      initialRate: 0.5,
+    };
+    const result = runHistorical(BASE_PARAMS, dataset, strategy);
+    expect(result.survivalRate).toBe(0);
+    expect(result.trajectories.every((t) => !t.survived)).toBe(true);
+  });
+});
+
+describe('runHistorical – output shapes', () => {
+  it('produces startDates, endingValues, and withdrawal arrays with length equal to periodCount', () => {
+    const horizonMonths = BASE_PARAMS.horizonYears * 12;
+    const dataset = makeDataset(horizonMonths + 5, 0.005, 0.004, 0.002);
+    const result = runHistorical(BASE_PARAMS, dataset, FIXED_PCT_STRATEGY);
+    const { periodCount } = result;
+
+    expect(result.startDates).toHaveLength(periodCount);
+    expect(result.endingNominalValues).toHaveLength(periodCount);
+    expect(result.endingRealValues).toHaveLength(periodCount);
+    expect(result.trajectories).toHaveLength(periodCount);
+    expect(result.nominalWithdrawalsPerYear).toHaveLength(BASE_PARAMS.horizonYears);
+    expect(result.realWithdrawalsPerYear).toHaveLength(BASE_PARAMS.horizonYears);
+    for (let y = 0; y < BASE_PARAMS.horizonYears; y++) {
+      expect(result.nominalWithdrawalsPerYear[y]).toHaveLength(periodCount);
+      expect(result.realWithdrawalsPerYear[y]).toHaveLength(periodCount);
+    }
+  });
+
+  it('uses a fresh strategy closure for each period so stateful strategies are independent', () => {
+    const horizonMonths = BASE_PARAMS.horizonYears * 12;
+    // Use a Guyton-Klinger strategy whose state must not bleed between periods
+    const dataset = makeDataset(horizonMonths + 2, 0.005, 0.004, 0.002);
+    const gkStrategy: StrategyParams = {
+      id: 'gk',
+      initialPortfolio: BASE_PARAMS.initialPortfolio,
+      initialRate: 0.04,
+    };
+    const result = runHistorical(BASE_PARAMS, dataset, gkStrategy);
+    // Both periods start from the same initial state, so year-0 withdrawals must be equal
+    expect(result.nominalWithdrawalsPerYear[0][0]).toBeCloseTo(
+      result.nominalWithdrawalsPerYear[0][1],
+      6,
+    );
+  });
+});
+
+describe('runHistorical – depletion details', () => {
+  // GK at 50 % initial rate with 0 % returns guarantees depletion in every period
+  const depletionStrategy: StrategyParams = {
+    id: 'gk',
+    initialPortfolio: BASE_PARAMS.initialPortfolio,
+    initialRate: 0.5,
+  };
+
+  it('records a depletionMonth for each trajectory that did not survive', () => {
+    const horizonMonths = BASE_PARAMS.horizonYears * 12;
+    const dataset = makeDataset(horizonMonths + 3, 0.0, 0.0, 0.0);
+    const result = runHistorical(BASE_PARAMS, dataset, depletionStrategy);
+    for (const t of result.trajectories) {
+      expect(t.depletionMonth).toBeDefined();
+    }
+  });
+
+  it('ending nominal values are zero for all depleted periods', () => {
+    const horizonMonths = BASE_PARAMS.horizonYears * 12;
+    const dataset = makeDataset(horizonMonths + 2, 0.0, 0.0, 0.0);
+    const result = runHistorical(BASE_PARAMS, dataset, depletionStrategy);
+    for (const v of result.endingNominalValues) {
+      expect(v).toBe(0);
+    }
+  });
+});

--- a/src/lib/runners/historical.ts
+++ b/src/lib/runners/historical.ts
@@ -1,0 +1,114 @@
+import type { SimParams, Trajectory } from '../simulation/types';
+import type { MarketDataset } from '../data/types';
+import type { StrategyParams } from '../strategies/types';
+import { runMonthlyEngine } from '../simulation/engine';
+import { createStrategy } from '../strategies/index';
+
+/**
+ * Aggregated result of running the simulation over every valid rolling
+ * start period in the historical dataset.
+ */
+export interface HistoricalResult {
+  /** Number of rolling periods simulated. */
+  periodCount: number;
+  /** Fraction of periods where the portfolio survived to the final month (0–1). */
+  survivalRate: number;
+  /** ISO start date ("YYYY-MM") of each rolling period; length = periodCount. */
+  startDates: string[];
+  /** Nominal balance at the final month for each period; length = periodCount. */
+  endingNominalValues: number[];
+  /** Real balance (month-0 dollars) at the final month for each period; length = periodCount. */
+  endingRealValues: number[];
+  /**
+   * Nominal withdrawal amounts indexed by [yearIndex][periodIndex].
+   * Outer length = horizonYears; inner length = periodCount.
+   */
+  nominalWithdrawalsPerYear: number[][];
+  /**
+   * Real withdrawal amounts (month-0 dollars) indexed by [yearIndex][periodIndex].
+   * Outer length = horizonYears; inner length = periodCount.
+   */
+  realWithdrawalsPerYear: number[][];
+  /** Individual trajectories for each rolling period; length = periodCount. */
+  trajectories: Trajectory[];
+}
+
+/**
+ * Runs the simulation engine over every valid rolling start period in the
+ * historical dataset and returns aggregated outputs.
+ *
+ * A start index `i` is valid when `i + horizonMonths <= dataset.usEquity.length`,
+ * ensuring each period has a full complement of return / inflation data.
+ *
+ * A fresh strategy closure is created for each period so that stateful
+ * strategies (e.g. Guyton-Klinger) start clean.
+ */
+export function runHistorical(
+  params: SimParams,
+  dataset: MarketDataset,
+  strategy: StrategyParams,
+): HistoricalResult {
+  const horizonMonths = params.horizonYears * 12;
+  const totalDataMonths = dataset.usEquity.length;
+
+  const startDates: string[] = [];
+  const endingNominalValues: number[] = [];
+  const endingRealValues: number[] = [];
+  const trajectories: Trajectory[] = [];
+  const nominalWithdrawalsPerYear: number[][] = Array.from(
+    { length: params.horizonYears },
+    () => [] as number[],
+  );
+  const realWithdrawalsPerYear: number[][] = Array.from(
+    { length: params.horizonYears },
+    () => [] as number[],
+  );
+  let survivalCount = 0;
+
+  for (let start = 0; start + horizonMonths <= totalDataMonths; start++) {
+    const usReturns = dataset.usEquity
+      .slice(start, start + horizonMonths)
+      .map((r) => r.value);
+    const intlReturns = dataset.intlEquity
+      .slice(start, start + horizonMonths)
+      .map((r) => r.value);
+    const inflation = dataset.cpi
+      .slice(start, start + horizonMonths)
+      .map((r) => r.value);
+
+    const withdrawalFn = createStrategy(strategy);
+    const trajectory = runMonthlyEngine(
+      params,
+      usReturns,
+      intlReturns,
+      inflation,
+      withdrawalFn,
+    );
+
+    startDates.push(dataset.usEquity[start].date);
+    endingNominalValues.push(trajectory.nominalBalance[horizonMonths - 1]);
+    endingRealValues.push(trajectory.realBalance[horizonMonths - 1]);
+    trajectories.push(trajectory);
+
+    if (trajectory.survived) survivalCount++;
+
+    for (let y = 0; y < params.horizonYears; y++) {
+      nominalWithdrawalsPerYear[y].push(trajectory.nominalWithdrawal[y]);
+      realWithdrawalsPerYear[y].push(trajectory.realWithdrawal[y]);
+    }
+  }
+
+  const periodCount = startDates.length;
+  const survivalRate = periodCount > 0 ? survivalCount / periodCount : 0;
+
+  return {
+    periodCount,
+    survivalRate,
+    startDates,
+    endingNominalValues,
+    endingRealValues,
+    nominalWithdrawalsPerYear,
+    realWithdrawalsPerYear,
+    trajectories,
+  };
+}


### PR DESCRIPTION
## What
Adds `runHistorical()` — the glue layer that drives the monthly simulation engine over every valid rolling start period in the historical dataset and returns aggregated outputs (survival rate, ending-value distribution, per-year withdrawal distributions, and individual trajectories).

## Changes
- `src/lib/runners/historical.ts` — `runHistorical(params, dataset, strategy): HistoricalResult`; enumerates start indices where `start + horizonMonths <= datasetLength`, slices returns/inflation for each, creates a fresh strategy closure, runs the engine, and aggregates
- `src/lib/runners/historical.test.ts` — 9 tests covering period count arithmetic, 100 % survival on strongly positive dataset, 0 % survival with an unsustainably high GK rate, output array shape invariants, stateful-strategy isolation, and depletion recording

## How to test
1. `npm test -- --run` → 55 tests, 0 failing
2. `npm run type-check` → no errors
3. `npm run lint` → no errors
4. `npm run build` → succeeds

## Manual steps
- None

## Test results
- All tests: 55 passing, 0 failing
- New tests: 9 in `src/lib/runners/historical.test.ts`

## Out of scope
Monte Carlo runner (separate issue), UI wiring, and serialisation/caching of results — none of these were in scope for this PR.

## Checklist
- [x] Tests / types / lint / build all green
- [x] No secrets or env vars in code
- [x] `.env.example` updated if new env vars
- [x] No debug statements committed
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commits or metadata
- [x] Schema changes have migrations (if applicable)

Fixes #J-15