### PR TITLE
feat(metrics): shared metrics aggregation

### DIFF
--- a/src/lib/metrics/aggregate.test.ts
+++ b/src/lib/metrics/aggregate.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest';
+import { aggregate } from './aggregate';
+import type { Trajectory } from '../simulation/types';
+
+/** Builds a minimal Trajectory with 1-year horizon (12 months). */
+function makeTrajectory(opts: {
+  realBalance: number[];
+  realWithdrawal?: number[];
+  survived: boolean;
+  depletionMonth?: number;
+}): Trajectory {
+  const months = opts.realBalance.length;
+  return {
+    nominalBalance: opts.realBalance.slice(),
+    realBalance: opts.realBalance,
+    cumulativeInflation: Array(months).fill(1),
+    nominalWithdrawal: opts.realWithdrawal ?? [],
+    realWithdrawal: opts.realWithdrawal ?? [],
+    survived: opts.survived,
+    depletionMonth: opts.depletionMonth,
+  };
+}
+
+/** Constant real balance across all months; a trivially surviving trajectory. */
+function flatTrajectory(balance: number, months = 12, annualWithdrawal = 0): Trajectory {
+  return makeTrajectory({
+    realBalance: Array(months).fill(balance),
+    realWithdrawal: Array(Math.floor(months / 12)).fill(annualWithdrawal),
+    survived: true,
+  });
+}
+
+describe('aggregate – empty input', () => {
+  it('returns zeroed metrics when trajectory array is empty', () => {
+    const result = aggregate([]);
+    expect(result.trajectoryCount).toBe(0);
+    expect(result.survivalRate).toBe(0);
+    expect(result.endingRealValue.mean).toBe(0);
+    expect(result.endingRealValue.median).toBe(0);
+    expect(result.realWithdrawal.mean).toBe(0);
+    expect(result.failureYearDistribution).toEqual({});
+    expect(result.meanMaxDrawdown).toBe(0);
+  });
+});
+
+describe('aggregate – survival rate', () => {
+  it('reports 1 when all trajectories survive', () => {
+    const t1 = flatTrajectory(1_000_000);
+    const t2 = flatTrajectory(800_000);
+    const result = aggregate([t1, t2]);
+    expect(result.survivalRate).toBe(1);
+    expect(result.trajectoryCount).toBe(2);
+  });
+
+  it('reports 0 when no trajectories survive', () => {
+    const failed = makeTrajectory({
+      realBalance: [1_000_000, 500_000, 0, 0],
+      survived: false,
+      depletionMonth: 2,
+    });
+    const result = aggregate([failed, { ...failed }]);
+    expect(result.survivalRate).toBe(0);
+  });
+
+  it('reports the correct fraction when half survive', () => {
+    const surviving = flatTrajectory(1_000_000);
+    const failed = makeTrajectory({
+      realBalance: [1_000_000, 0],
+      survived: false,
+      depletionMonth: 1,
+    });
+    const result = aggregate([surviving, failed]);
+    expect(result.survivalRate).toBe(0.5);
+  });
+});
+
+describe('aggregate – ending real value statistics', () => {
+  it('computes mean, median, and percentiles for two trajectories with known ending values', () => {
+    // t1 ends at 1_000_000; t2 ends at 2_000_000
+    const t1 = flatTrajectory(1_000_000);
+    const t2 = flatTrajectory(2_000_000);
+    const result = aggregate([t1, t2]);
+
+    // mean = 1_500_000; median = linear interp at 0.5 → 1_500_000
+    expect(result.endingRealValue.mean).toBeCloseTo(1_500_000);
+    expect(result.endingRealValue.median).toBeCloseTo(1_500_000);
+    // p10 = interp at index 0.1 → 1_000_000 + 0.1 * 1_000_000 = 1_100_000
+    expect(result.endingRealValue.p10).toBeCloseTo(1_100_000);
+    // p90 = interp at index 0.9 → 1_000_000 + 0.9 * 1_000_000 = 1_900_000
+    expect(result.endingRealValue.p90).toBeCloseTo(1_900_000);
+  });
+
+  it('computes correct percentiles for four equally spaced values', () => {
+    // ending values sorted: 100, 200, 300, 400
+    const trajectories = [100, 200, 300, 400].map((v) => flatTrajectory(v));
+    const result = aggregate(trajectories);
+
+    // mean = 250
+    expect(result.endingRealValue.mean).toBeCloseTo(250);
+    // median: p50 → index 1.5 → interp(200, 300, 0.5) = 250
+    expect(result.endingRealValue.median).toBeCloseTo(250);
+    // p25: index 0.75 → interp(100, 200, 0.75) = 175
+    expect(result.endingRealValue.p25).toBeCloseTo(175);
+    // p75: index 2.25 → interp(300, 400, 0.25) = 325
+    expect(result.endingRealValue.p75).toBeCloseTo(325);
+    // p10: index 0.3 → interp(100, 200, 0.3) = 130
+    expect(result.endingRealValue.p10).toBeCloseTo(130);
+    // p90: index 2.7 → interp(300, 400, 0.7) = 370
+    expect(result.endingRealValue.p90).toBeCloseTo(370);
+  });
+});
+
+describe('aggregate – withdrawal statistics', () => {
+  it('computes mean, median, and variance over all real withdrawals', () => {
+    // t1 has real withdrawals [40_000, 42_000]; t2 has [38_000, 40_000]
+    // flat pool: [40_000, 42_000, 38_000, 40_000]
+    // mean = 160_000 / 4 = 40_000
+    // sorted: [38_000, 40_000, 40_000, 42_000]
+    // median: p50 at index 1.5 → interp(40_000, 40_000, 0.5) = 40_000
+    // variance: deviations² = [0, 4_000_000, 4_000_000, 0] → mean = 2_000_000
+    const t1 = makeTrajectory({
+      realBalance: Array(24).fill(1_000_000),
+      realWithdrawal: [40_000, 42_000],
+      survived: true,
+    });
+    const t2 = makeTrajectory({
+      realBalance: Array(24).fill(1_000_000),
+      realWithdrawal: [38_000, 40_000],
+      survived: true,
+    });
+    const result = aggregate([t1, t2]);
+
+    expect(result.realWithdrawal.mean).toBeCloseTo(40_000);
+    expect(result.realWithdrawal.median).toBeCloseTo(40_000);
+    expect(result.realWithdrawal.variance).toBeCloseTo(2_000_000);
+  });
+
+  it('handles single trajectory with single-year withdrawal', () => {
+    const t = makeTrajectory({
+      realBalance: Array(12).fill(500_000),
+      realWithdrawal: [20_000],
+      survived: true,
+    });
+    const result = aggregate([t]);
+    expect(result.realWithdrawal.mean).toBe(20_000);
+    expect(result.realWithdrawal.median).toBe(20_000);
+    expect(result.realWithdrawal.variance).toBe(0);
+  });
+});
+
+describe('aggregate – max drawdown', () => {
+  it('reports zero drawdown for a monotonically increasing balance', () => {
+    const t = makeTrajectory({
+      realBalance: [100, 110, 120, 130, 140],
+      realWithdrawal: [],
+      survived: true,
+    });
+    const result = aggregate([t]);
+    expect(result.meanMaxDrawdown).toBeCloseTo(0);
+    expect(result.medianMaxDrawdown).toBeCloseTo(0);
+  });
+
+  it('computes 50 % drawdown for a balance that halves from its peak', () => {
+    // rises to 200, falls to 100 → 50 % drawdown
+    const t = makeTrajectory({
+      realBalance: [100, 150, 200, 150, 100],
+      realWithdrawal: [],
+      survived: true,
+    });
+    const result = aggregate([t]);
+    expect(result.meanMaxDrawdown).toBeCloseTo(0.5);
+  });
+
+  it('averages max drawdown correctly across multiple trajectories', () => {
+    // t1: peak 200, trough 100 → 50 % drawdown
+    const t1 = makeTrajectory({ realBalance: [200, 100], survived: true });
+    // t2: peak 100, trough 100 → 0 % drawdown (flat)
+    const t2 = makeTrajectory({ realBalance: [100, 100], survived: true });
+    const result = aggregate([t1, t2]);
+    expect(result.meanMaxDrawdown).toBeCloseTo(0.25);
+    expect(result.medianMaxDrawdown).toBeCloseTo(0.25);
+  });
+});
+
+describe('aggregate – failure year distribution', () => {
+  it('builds an empty distribution when all trajectories survive', () => {
+    const result = aggregate([flatTrajectory(1_000_000), flatTrajectory(800_000)]);
+    expect(result.failureYearDistribution).toEqual({});
+  });
+
+  it('records the correct year for a trajectory that depletes in month 13 (year 1)', () => {
+    const failed = makeTrajectory({
+      realBalance: Array(24).fill(0),
+      survived: false,
+      depletionMonth: 13,
+    });
+    const result = aggregate([failed]);
+    expect(result.failureYearDistribution[1]).toBe(1);
+  });
+
+  it('accumulates counts for multiple failures in the same year', () => {
+    const makeFailedAt = (month: number): Trajectory =>
+      makeTrajectory({
+        realBalance: Array(24).fill(0),
+        survived: false,
+        depletionMonth: month,
+      });
+    // months 0–11 → year 0; months 12–23 → year 1
+    const result = aggregate([
+      makeFailedAt(0),
+      makeFailedAt(6),
+      makeFailedAt(12),
+    ]);
+    expect(result.failureYearDistribution[0]).toBe(2);
+    expect(result.failureYearDistribution[1]).toBe(1);
+  });
+
+  it('ignores failed trajectories where depletionMonth is undefined', () => {
+    const t = makeTrajectory({ realBalance: [0], survived: false });
+    const result = aggregate([t]);
+    expect(result.failureYearDistribution).toEqual({});
+  });
+});
+
+describe('aggregate – percentile boundary cases', () => {
+  it('returns the single value for all percentiles when there is one trajectory', () => {
+    const result = aggregate([flatTrajectory(750_000)]);
+    expect(result.endingRealValue.p10).toBeCloseTo(750_000);
+    expect(result.endingRealValue.p25).toBeCloseTo(750_000);
+    expect(result.endingRealValue.median).toBeCloseTo(750_000);
+    expect(result.endingRealValue.p75).toBeCloseTo(750_000);
+    expect(result.endingRealValue.p90).toBeCloseTo(750_000);
+  });
+
+  it('handles trajectories with zero ending real balance (complete depletion)', () => {
+    const depleted = makeTrajectory({
+      realBalance: Array(12).fill(0),
+      survived: false,
+      depletionMonth: 0,
+    });
+    const surviving = flatTrajectory(1_000_000);
+    const result = aggregate([depleted, surviving]);
+    // ending values: [0, 1_000_000] sorted; p10 = 0 + 0.1 * 1_000_000 = 100_000
+    expect(result.endingRealValue.p10).toBeCloseTo(100_000);
+    expect(result.endingRealValue.mean).toBeCloseTo(500_000);
+  });
+});

--- a/src/lib/metrics/aggregate.ts
+++ b/src/lib/metrics/aggregate.ts
@@ -1,0 +1,131 @@
+import type { Trajectory } from '../simulation/types';
+
+export interface EndingValueStats {
+  mean: number;
+  median: number;
+  p10: number;
+  p25: number;
+  p75: number;
+  p90: number;
+}
+
+export interface WithdrawalStats {
+  mean: number;
+  median: number;
+  /** Population variance of all real annual withdrawals across all trajectories. */
+  variance: number;
+}
+
+export interface AggregateMetrics {
+  trajectoryCount: number;
+  survivalRate: number;
+  endingRealValue: EndingValueStats;
+  realWithdrawal: WithdrawalStats;
+  /** Failure year index (0-based) → count of trajectories that depleted in that year. */
+  failureYearDistribution: Record<number, number>;
+  /** Mean max peak-to-trough drawdown in real balance across all trajectories (0–1). */
+  meanMaxDrawdown: number;
+  /** Median max drawdown across all trajectories (0–1). */
+  medianMaxDrawdown: number;
+}
+
+function arithmeticMean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+/** Linear interpolation percentile on a pre-sorted array. p in [0, 1]. */
+function percentileOf(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+  const idx = p * (sorted.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+function endingValueStats(values: number[]): EndingValueStats {
+  const sorted = [...values].sort((a, b) => a - b);
+  return {
+    mean: arithmeticMean(values),
+    median: percentileOf(sorted, 0.5),
+    p10: percentileOf(sorted, 0.1),
+    p25: percentileOf(sorted, 0.25),
+    p75: percentileOf(sorted, 0.75),
+    p90: percentileOf(sorted, 0.9),
+  };
+}
+
+function withdrawalStats(values: number[]): WithdrawalStats {
+  if (values.length === 0) return { mean: 0, median: 0, variance: 0 };
+  const sorted = [...values].sort((a, b) => a - b);
+  const mu = arithmeticMean(values);
+  const variance = arithmeticMean(values.map((v) => (v - mu) ** 2));
+  return {
+    mean: mu,
+    median: percentileOf(sorted, 0.5),
+    variance,
+  };
+}
+
+/** Max peak-to-trough drawdown for a single series (0 = no drawdown, 1 = full wipeout). */
+function maxDrawdown(values: number[]): number {
+  if (values.length === 0) return 0;
+  let peak = values[0];
+  let dd = 0;
+  for (const v of values) {
+    if (v > peak) peak = v;
+    const cur = peak > 0 ? (peak - v) / peak : 0;
+    if (cur > dd) dd = cur;
+  }
+  return dd;
+}
+
+/**
+ * Computes unified summary metrics over an array of trajectories.
+ * Returns a zeroed-out result when the array is empty.
+ */
+export function aggregate(trajectories: Trajectory[]): AggregateMetrics {
+  const count = trajectories.length;
+
+  if (count === 0) {
+    return {
+      trajectoryCount: 0,
+      survivalRate: 0,
+      endingRealValue: { mean: 0, median: 0, p10: 0, p25: 0, p75: 0, p90: 0 },
+      realWithdrawal: { mean: 0, median: 0, variance: 0 },
+      failureYearDistribution: {},
+      meanMaxDrawdown: 0,
+      medianMaxDrawdown: 0,
+    };
+  }
+
+  const survivalCount = trajectories.filter((t) => t.survived).length;
+  const survivalRate = survivalCount / count;
+
+  const endingReals = trajectories.map((t) => t.realBalance[t.realBalance.length - 1]);
+
+  // Flatten all real annual withdrawals across every trajectory and every year.
+  const allRealWithdrawals = trajectories.flatMap((t) => t.realWithdrawal);
+
+  const failureYearDistribution: Record<number, number> = {};
+  for (const t of trajectories) {
+    if (!t.survived && t.depletionMonth !== undefined) {
+      const year = Math.floor(t.depletionMonth / 12);
+      failureYearDistribution[year] = (failureYearDistribution[year] ?? 0) + 1;
+    }
+  }
+
+  const drawdowns = trajectories.map((t) => maxDrawdown(t.realBalance));
+  const sortedDrawdowns = [...drawdowns].sort((a, b) => a - b);
+
+  return {
+    trajectoryCount: count,
+    survivalRate,
+    endingRealValue: endingValueStats(endingReals),
+    realWithdrawal: withdrawalStats(allRealWithdrawals),
+    failureYearDistribution,
+    meanMaxDrawdown: arithmeticMean(drawdowns),
+    medianMaxDrawdown: percentileOf(sortedDrawdowns, 0.5),
+  };
+}

--- a/src/lib/montecarlo/types.ts
+++ b/src/lib/montecarlo/types.ts
@@ -1,4 +1,5 @@
 import type { Trajectory } from '../simulation/types';
+import type { AggregateMetrics } from '../metrics/aggregate';
 
 /** Configuration for the stationary block bootstrap generator. */
 export interface BlockBootstrapConfig {
@@ -96,6 +97,8 @@ export interface MonteCarloResult {
    * Length = min(keepTrajectories, pathCount).
    */
   trajectories: Trajectory[];
+  /** Unified summary metrics computed over ALL paths (not the sampled subset). */
+  metrics: AggregateMetrics;
 }
 
 /**

--- a/src/lib/runners/historical.ts
+++ b/src/lib/runners/historical.ts
@@ -1,8 +1,10 @@
 import type { SimParams, Trajectory } from '../simulation/types';
 import type { MarketDataset } from '../data/types';
 import type { StrategyParams } from '../strategies/types';
+import type { AggregateMetrics } from '../metrics/aggregate';
 import { runMonthlyEngine } from '../simulation/engine';
 import { createStrategy } from '../strategies/index';
+import { aggregate } from '../metrics/aggregate';
 
 /**
  * Aggregated result of running the simulation over every valid rolling
@@ -31,6 +33,8 @@ export interface HistoricalResult {
   realWithdrawalsPerYear: number[][];
   /** Individual trajectories for each rolling period; length = periodCount. */
   trajectories: Trajectory[];
+  /** Unified summary metrics computed over all trajectories. */
+  metrics: AggregateMetrics;
 }
 
 /**
@@ -110,5 +114,6 @@ export function runHistorical(
     nominalWithdrawalsPerYear,
     realWithdrawalsPerYear,
     trajectories,
+    metrics: aggregate(trajectories),
   };
 }

--- a/src/lib/runners/montecarlo.ts
+++ b/src/lib/runners/montecarlo.ts
@@ -7,6 +7,7 @@ import { createStrategy } from '../strategies/index';
 import { calibrateFromHistorical } from '../montecarlo/calibrate';
 import { createBlockBootstrapGenerator } from '../montecarlo/generate';
 import { deriveSeed } from '../montecarlo/prng';
+import { aggregate } from '../metrics/aggregate';
 
 const DEFAULT_KEEP_TRAJECTORIES = 200;
 
@@ -112,6 +113,7 @@ export function runMonteCarlo(
     }
   }
 
+  const metrics = aggregate(allTrajectories);
   const trajectories = sampleTrajectories(allTrajectories, endingRealValues, keepCount);
   const survivalRate = config.pathCount > 0 ? survivalCount / config.pathCount : 0;
 
@@ -124,5 +126,6 @@ export function runMonteCarlo(
     nominalWithdrawalsPerYear,
     realWithdrawalsPerYear,
     trajectories,
+    metrics,
   };
 }


### PR DESCRIPTION
## What
Adds a unified `aggregate(trajectories)` function that both runners feed into, so historical and Monte Carlo results expose the same set of output metrics and are directly comparable (PRD §12).

## Changes
- `src/lib/metrics/aggregate.ts` — pure `aggregate(trajectories: Trajectory[]): AggregateMetrics` computing survival rate, ending-value mean/median/p10/p25/p75/p90, real-withdrawal mean/median/variance, per-trajectory max drawdown (mean + median), and failure-year distribution
- `src/lib/metrics/aggregate.test.ts` — 17 tests covering each metric group, percentile boundary cases, and edge inputs (empty array, single trajectory, zero-balance, undefined depletionMonth)
- `src/lib/runners/historical.ts` — `HistoricalResult` gains `metrics: AggregateMetrics`; runner calls `aggregate(trajectories)` before returning
- `src/lib/runners/montecarlo.ts` — calls `aggregate(allTrajectories)` over all paths before sampling; result gains `metrics: AggregateMetrics`
- `src/lib/montecarlo/types.ts` — `MonteCarloResult` gains `metrics: AggregateMetrics`

## How to test
1. `npm test` — all 108 tests should pass including the 17 new ones
2. Verify `runHistorical(…).metrics.survivalRate` matches `runHistorical(…).survivalRate`
3. Verify `runMonteCarlo(…).metrics.survivalRate` matches `runMonteCarlo(…).survivalRate`

## Manual steps
- None

## Test results
- All tests: 108 passing, 0 failing
- New tests: 17 in `src/lib/metrics/aggregate.test.ts`

## Out of scope
- Exposing metrics in the UI — that's a separate PR
- Additional percentile levels (e.g. p5/p95) — can be added when the UI specifies them

## Checklist
- [x] Tests / types / lint / build all green
- [x] No secrets or env vars in code
- [x] `.env.example` not affected
- [x] No debug statements committed
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commits or metadata
- [x] Schema changes have migrations (not applicable)

Fixes J-17