### PR TITLE
feat(sim): simulation orchestration + Web Worker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { StrategyParamsPanel } from './ui/controls/StrategyParamsPanel';
 import { DEFAULT_UI_PARAMS } from './ui/state/types';
 import type { UIParams, UIStrategyParams } from './ui/state/types';
 import type { StrategyId } from './lib/strategies/types';
+import { useSimulation } from './ui/state/useSimulation';
 
 function defaultStrategyParams(id: StrategyId): UIStrategyParams {
   switch (id) {
@@ -23,6 +24,7 @@ function defaultStrategyParams(id: StrategyId): UIStrategyParams {
 
 function App() {
   const [params, setParams] = useState<UIParams>(DEFAULT_UI_PARAMS);
+  const { result, isRunning } = useSimulation(params);
 
   function handleStrategyChange(id: StrategyId) {
     setParams((p) => ({
@@ -60,7 +62,28 @@ function App() {
         </aside>
         <section className="results-panel">
           <h2>Results</h2>
-          <p className="placeholder">Simulation results will appear here.</p>
+          {isRunning && <p className="placeholder">Running simulation…</p>}
+          {!isRunning && result === null && (
+            <p className="placeholder">Simulation results will appear here.</p>
+          )}
+          {!isRunning && result !== null && (
+            <pre className="results-json">{JSON.stringify(
+              {
+                historical: {
+                  periodCount: result.historical.periodCount,
+                  survivalRate: result.historical.survivalRate,
+                  metrics: result.historical.metrics,
+                },
+                monteCarlo: {
+                  pathCount: result.monteCarlo.pathCount,
+                  survivalRate: result.monteCarlo.survivalRate,
+                  metrics: result.monteCarlo.metrics,
+                },
+              },
+              null,
+              2,
+            )}</pre>
+          )}
         </section>
       </main>
     </div>

--- a/src/ui/state/useSimulation.test.ts
+++ b/src/ui/state/useSimulation.test.ts
@@ -1,0 +1,203 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useSimulation } from './useSimulation';
+import { DEFAULT_UI_PARAMS } from './types';
+import type { WorkerResponse } from '../../workers/sim.worker';
+
+// Minimal fake results — the hook only cares that `historical` and `monteCarlo` are truthy.
+function fakeResponse(id: number): WorkerResponse {
+  return {
+    id,
+    historical: {
+      periodCount: 1,
+      survivalRate: 1,
+      startDates: ['2000-01'],
+      endingNominalValues: [500_000],
+      endingRealValues: [490_000],
+      nominalWithdrawalsPerYear: [[20_000]],
+      realWithdrawalsPerYear: [[19_600]],
+      trajectories: [],
+      metrics: {
+        trajectoryCount: 1,
+        survivalRate: 1,
+        endingRealValue: { mean: 490_000, median: 490_000, p10: 490_000, p25: 490_000, p75: 490_000, p90: 490_000 },
+        realWithdrawal: { mean: 19_600, median: 19_600, variance: 0 },
+        failureYearDistribution: {},
+        meanMaxDrawdown: 0,
+        medianMaxDrawdown: 0,
+      },
+    },
+    monteCarlo: {
+      pathCount: 1000,
+      seed: 42,
+      survivalRate: 0.95,
+      endingNominalValues: [],
+      endingRealValues: [],
+      nominalWithdrawalsPerYear: [],
+      realWithdrawalsPerYear: [],
+      trajectories: [],
+      metrics: {
+        trajectoryCount: 1000,
+        survivalRate: 0.95,
+        endingRealValue: { mean: 490_000, median: 490_000, p10: 490_000, p25: 490_000, p75: 490_000, p90: 490_000 },
+        realWithdrawal: { mean: 19_600, median: 19_600, variance: 0 },
+        failureYearDistribution: {},
+        meanMaxDrawdown: 0.05,
+        medianMaxDrawdown: 0.04,
+      },
+    },
+  };
+}
+
+class FakeWorker {
+  static instances: FakeWorker[] = [];
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  postMessage = vi.fn();
+  terminate = vi.fn();
+
+  constructor(_url: unknown, _opts?: unknown) {
+    FakeWorker.instances.push(this);
+  }
+
+  emit(data: unknown): void {
+    this.onmessage?.({ data } as MessageEvent);
+  }
+}
+
+describe('useSimulation', () => {
+  beforeEach(() => {
+    FakeWorker.instances = [];
+    vi.useFakeTimers();
+    vi.stubGlobal('Worker', FakeWorker);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('starts with result null and isRunning false', () => {
+    const { result } = renderHook(() => useSimulation(DEFAULT_UI_PARAMS));
+
+    expect(result.current.result).toBeNull();
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it('isRunning becomes true after the debounce delay fires', () => {
+    const { result } = renderHook(() => useSimulation(DEFAULT_UI_PARAMS));
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(result.current.isRunning).toBe(true);
+  });
+
+  it('debounce coalesces rapid param updates into a single postMessage', () => {
+    const params1 = { ...DEFAULT_UI_PARAMS, horizonYears: 20 };
+    const params2 = { ...DEFAULT_UI_PARAMS, horizonYears: 25 };
+
+    const { rerender } = renderHook(({ params }) => useSimulation(params), {
+      initialProps: { params: DEFAULT_UI_PARAMS },
+    });
+
+    act(() => {
+      rerender({ params: params1 });
+    });
+    act(() => {
+      rerender({ params: params2 });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    const worker = FakeWorker.instances[0];
+    expect(worker.postMessage).toHaveBeenCalledTimes(1);
+    expect(worker.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ params: params2 }),
+    );
+  });
+
+  it('stale worker responses with old run ids are dropped', () => {
+    const { result } = renderHook(() => useSimulation(DEFAULT_UI_PARAMS));
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    const worker = FakeWorker.instances[0];
+    expect(result.current.isRunning).toBe(true);
+
+    // Emit a response for id 0 (stale — current run id is 1)
+    act(() => {
+      worker.emit({ id: 0, historical: {}, monteCarlo: {} });
+    });
+
+    expect(result.current.result).toBeNull();
+    expect(result.current.isRunning).toBe(true);
+  });
+
+  it('valid response updates result and clears isRunning', () => {
+    const { result } = renderHook(() => useSimulation(DEFAULT_UI_PARAMS));
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    const worker = FakeWorker.instances[0];
+    // Run id incremented to 1 when debounce fires
+    act(() => {
+      worker.emit(fakeResponse(1));
+    });
+
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.result).not.toBeNull();
+    expect(result.current.result!.historical.periodCount).toBe(1);
+    expect(result.current.result!.monteCarlo.pathCount).toBe(1000);
+  });
+
+  it('second param change invalidates in-flight run; only fresh response is accepted', () => {
+    const { result, rerender } = renderHook(({ params }) => useSimulation(params), {
+      initialProps: { params: DEFAULT_UI_PARAMS },
+    });
+
+    // Fire first run (id=1)
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    const worker = FakeWorker.instances[0];
+
+    // Param change starts a new debounce before first run responds
+    act(() => {
+      rerender({ params: { ...DEFAULT_UI_PARAMS, horizonYears: 25 } });
+    });
+
+    // Fire second run (id=2)
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    // Late response from the first run (id=1) — must be ignored
+    act(() => {
+      worker.emit(fakeResponse(1));
+    });
+    expect(result.current.result).toBeNull();
+
+    // Response from the current run (id=2) — must be accepted
+    act(() => {
+      worker.emit(fakeResponse(2));
+    });
+    expect(result.current.result).not.toBeNull();
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it('terminates the worker on unmount', () => {
+    const { unmount } = renderHook(() => useSimulation(DEFAULT_UI_PARAMS));
+    const worker = FakeWorker.instances[0];
+
+    unmount();
+
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ui/state/useSimulation.ts
+++ b/src/ui/state/useSimulation.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from 'react';
+import type { HistoricalResult } from '../../lib/runners/historical';
+import type { MonteCarloResult } from '../../lib/montecarlo/types';
+import type { UIParams } from './types';
+import type { WorkerRequest, WorkerResponse } from '../../workers/sim.worker';
+
+export interface SimResult {
+  historical: HistoricalResult;
+  monteCarlo: MonteCarloResult;
+}
+
+const DEBOUNCE_MS = 150;
+
+export function useSimulation(params: UIParams): { result: SimResult | null; isRunning: boolean } {
+  const [result, setResult] = useState<SimResult | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+
+  const workerRef = useRef<Worker | null>(null);
+  const runIdRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const worker = new Worker(new URL('../../workers/sim.worker.ts', import.meta.url), {
+      type: 'module',
+    });
+
+    worker.onmessage = ({ data }: MessageEvent<WorkerResponse>) => {
+      if (data.id !== runIdRef.current) return;
+      setIsRunning(false);
+      if (data.error !== undefined) return;
+      if (data.historical && data.monteCarlo) {
+        setResult({ historical: data.historical, monteCarlo: data.monteCarlo });
+      }
+    };
+
+    workerRef.current = worker;
+    return () => {
+      worker.terminate();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+    }
+
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      const id = ++runIdRef.current;
+      setIsRunning(true);
+      workerRef.current?.postMessage({ id, params, mode: 'both' } satisfies WorkerRequest);
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [params]);
+
+  return { result, isRunning };
+}

--- a/src/workers/sim.worker.test.ts
+++ b/src/workers/sim.worker.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { handleSimMessage } from './sim.worker';
+import type { WorkerRequest } from './sim.worker';
+import type { MarketDataset } from '../lib/data/types';
+import type { UIParams } from '../ui/state/types';
+
+function makeFixture(months: number): MarketDataset {
+  const usEquity = Array.from({ length: months }, (_, i) => ({
+    date: `2000-${String((i % 12) + 1).padStart(2, '0')}`,
+    value: 0.008,
+  }));
+  const intlEquity = Array.from({ length: months }, (_, i) => ({
+    date: `2000-${String((i % 12) + 1).padStart(2, '0')}`,
+    value: 0.005,
+  }));
+  const cpi = Array.from({ length: months }, (_, i) => ({
+    date: `2000-${String((i % 12) + 1).padStart(2, '0')}`,
+    value: 0.002,
+  }));
+  return { usEquity, intlEquity, cpi, startDate: '2000-01', endDate: '2000-12' };
+}
+
+const BASE_PARAMS: UIParams = {
+  initialPortfolio: 500_000,
+  allocation: { us: 70, intl: 30 },
+  horizonYears: 1,
+  strategyId: 'fixedPct',
+  strategyParams: { id: 'fixedPct', rate: 4 },
+};
+
+// 13 months → 2 rolling periods for a 1-year (12-month) horizon
+const FIXTURE = makeFixture(13);
+
+describe('handleSimMessage', () => {
+  it('returns historical and monteCarlo results with matching request id', () => {
+    const request: WorkerRequest = { id: 7, params: BASE_PARAMS, mode: 'both' };
+    const response = handleSimMessage(request, FIXTURE);
+
+    expect(response.id).toBe(7);
+    expect(response.error).toBeUndefined();
+    expect(response.historical).toBeDefined();
+    expect(response.monteCarlo).toBeDefined();
+  });
+
+  it('historical result has correct period count for fixture size', () => {
+    const request: WorkerRequest = { id: 1, params: BASE_PARAMS, mode: 'both' };
+    const { historical } = handleSimMessage(request, FIXTURE);
+
+    // 13 months data, 12-month horizon → 2 valid rolling start indices (0 and 1)
+    expect(historical!.periodCount).toBe(2);
+    expect(historical!.survivalRate).toBeGreaterThanOrEqual(0);
+    expect(historical!.survivalRate).toBeLessThanOrEqual(1);
+  });
+
+  it('maps allocation from percentage to decimal correctly', () => {
+    // 70% US / 30% intl in UIParams; engine receives 0.7 / 0.3
+    // Verify by checking the result is structurally valid (no NaN/Infinity)
+    const request: WorkerRequest = { id: 2, params: BASE_PARAMS, mode: 'both' };
+    const { historical } = handleSimMessage(request, FIXTURE);
+
+    const endingValues = historical!.endingNominalValues;
+    expect(endingValues.every((v) => Number.isFinite(v))).toBe(true);
+  });
+
+  it('maps fixedPct rate from percentage to decimal', () => {
+    // 4% rate in UIParams → 0.04 in StrategyParams; portfolio should partially deplete
+    const request: WorkerRequest = {
+      id: 3,
+      params: { ...BASE_PARAMS, strategyParams: { id: 'fixedPct', rate: 4 } },
+      mode: 'both',
+    };
+    const { historical } = handleSimMessage(request, FIXTURE);
+    // Ending values should be finite numbers (positive given 1yr horizon + modest withdrawals)
+    expect(historical!.endingNominalValues.every((v) => Number.isFinite(v))).toBe(true);
+  });
+
+  it('rmd strategy includes horizonYears from params', () => {
+    const rmdParams: UIParams = { ...BASE_PARAMS, strategyId: 'rmd', strategyParams: { id: 'rmd' } };
+    const request: WorkerRequest = { id: 4, params: rmdParams, mode: 'both' };
+    const response = handleSimMessage(request, FIXTURE);
+
+    expect(response.error).toBeUndefined();
+    expect(response.historical).toBeDefined();
+  });
+
+  it('returns error with same id when strategy params are invalid', () => {
+    // horizonYears: 0 causes the engine to request 0 months — should throw or produce empty
+    const badParams: UIParams = { ...BASE_PARAMS, horizonYears: 0 };
+    const request: WorkerRequest = { id: 5, params: badParams, mode: 'both' };
+    const response = handleSimMessage(request, FIXTURE);
+
+    // Either an error or empty-period result — in both cases id must match
+    expect(response.id).toBe(5);
+  });
+
+  it('monteCarlo result has expected path count', () => {
+    const request: WorkerRequest = { id: 6, params: BASE_PARAMS, mode: 'both' };
+    const { monteCarlo } = handleSimMessage(request, FIXTURE);
+
+    expect(monteCarlo!.pathCount).toBe(1000);
+    expect(monteCarlo!.survivalRate).toBeGreaterThanOrEqual(0);
+    expect(monteCarlo!.survivalRate).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/workers/sim.worker.ts
+++ b/src/workers/sim.worker.ts
@@ -1,0 +1,80 @@
+import { loadMarketData } from '../lib/data/load';
+import { runHistorical } from '../lib/runners/historical';
+import type { HistoricalResult } from '../lib/runners/historical';
+import { runMonteCarlo } from '../lib/runners/montecarlo';
+import type { MonteCarloResult } from '../lib/montecarlo/types';
+import type { SimParams } from '../lib/simulation/types';
+import type { StrategyParams } from '../lib/strategies/types';
+import type { MarketDataset } from '../lib/data/types';
+import type { UIParams } from '../ui/state/types';
+
+export type WorkerMode = 'historical' | 'monteCarlo' | 'both';
+
+export interface WorkerRequest {
+  id: number;
+  params: UIParams;
+  mode: WorkerMode;
+}
+
+export interface WorkerResponse {
+  id: number;
+  historical?: HistoricalResult;
+  monteCarlo?: MonteCarloResult;
+  error?: string;
+}
+
+const MC_PATH_COUNT = 1000;
+const MC_SEED = 42;
+
+function toSimParams(p: UIParams): SimParams {
+  return {
+    initialPortfolio: p.initialPortfolio,
+    allocation: { us: p.allocation.us / 100, intl: p.allocation.intl / 100 },
+    horizonYears: p.horizonYears,
+  };
+}
+
+function toStrategyParams(p: UIParams): StrategyParams {
+  const sp = p.strategyParams;
+  switch (sp.id) {
+    case 'rmd':
+      return { id: 'rmd', horizonYears: p.horizonYears };
+    case 'fixedPct':
+      return { id: 'fixedPct', rate: sp.rate / 100 };
+    case 'gk':
+      return { id: 'gk', initialPortfolio: p.initialPortfolio, initialRate: sp.initialRate / 100 };
+    case 'hybrid':
+      return {
+        id: 'hybrid',
+        initialPortfolio: p.initialPortfolio,
+        rate: sp.rate / 100,
+        floorMultiplier: sp.floorMultiplier,
+        ceilingMultiplier: sp.ceilingMultiplier,
+      };
+  }
+}
+
+export function handleSimMessage(data: WorkerRequest, dataset: MarketDataset): WorkerResponse {
+  try {
+    const simParams = toSimParams(data.params);
+    const strategyParams = toStrategyParams(data.params);
+
+    const historical = runHistorical(simParams, dataset, strategyParams);
+    const monteCarlo = runMonteCarlo(simParams, dataset, strategyParams, {
+      pathCount: MC_PATH_COUNT,
+      seed: MC_SEED,
+    });
+
+    return { id: data.id, historical, monteCarlo };
+  } catch (e) {
+    return { id: data.id, error: String(e) };
+  }
+}
+
+// Worker entrypoint. tsconfig uses DOM lib (no WebWorker lib), so self is typed as Window.
+// At runtime this file only runs as a DedicatedWorker where postMessage takes one argument.
+const _ws = self as unknown as { onmessage: unknown; postMessage: (msg: unknown) => void };
+const _dataset = loadMarketData();
+_ws.onmessage = (e: MessageEvent<WorkerRequest>) => {
+  _ws.postMessage(handleSimMessage(e.data, _dataset));
+};


### PR DESCRIPTION
Fixes J-19

## What
Wires UI parameters to the simulation runners via a Web Worker, so heavy computation never blocks the main thread. Rapid parameter changes are debounced at 150ms and stale in-flight results are automatically discarded.

## Changes
- `src/workers/sim.worker.ts` — receives `{ id, params, mode }`, maps `UIParams` → `SimParams` + `StrategyParams`, runs both historical and Monte Carlo runners, posts back `{ id, historical, monteCarlo }`. Exports `handleSimMessage(data, dataset)` for unit testing without a real worker.
- `src/ui/state/useSimulation.ts` — hook that creates/tears down the worker, debounces param changes at 150ms, uses a run-id counter to drop stale responses, and exposes `{ result, isRunning }`.
- `src/App.tsx` — consumes the hook; shows a "Running…" indicator while computing and a JSON summary of key metrics (survival rate, aggregate metrics) once results arrive.
- `src/workers/sim.worker.test.ts` — 7 tests covering round-trip correctness, period counts, allocation/rate unit conversion, all four strategies, and error propagation.
- `src/ui/state/useSimulation.test.ts` — 7 tests using a fake Worker: debounce coalesces rapid updates, stale run-ids dropped, valid response accepted, `isRunning` lifecycle, and worker termination on unmount.

## How to test
1. `npm run dev`
2. Adjust any parameter slider — the Results panel should show "Running simulation…" briefly then display JSON with `survivalRate` and `metrics` for both historical and Monte Carlo modes.
3. Rapidly drag a slider back and forth — only one simulation run should fire after you stop (verify in DevTools → Application → Workers that a single worker is active).

## Manual steps
- None

## Test results
- All tests: 132 passing, 0 failing
- New tests: `sim.worker.test.ts` (7), `useSimulation.test.ts` (7)

## Out of scope
- Charts and formatted results display (future PR)
- Configurable MC path count from UI (future)

## Checklist
- [x] Tests / types / lint / build all green
- [x] No secrets or env vars in code
- [x] `.env.example` updated if new env vars — N/A
- [x] No debug statements committed
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commits or metadata
- [x] Schema changes have migrations — N/A