### PR TITLE
feat(viz): trajectory chart + summary metric cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
@@ -556,6 +557,42 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1172,6 +1209,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -1254,6 +1303,69 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1282,7 +1394,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1297,6 +1409,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.1",
@@ -2056,6 +2174,15 @@
         "node": ">= 16"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2136,8 +2263,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -2230,6 +2478,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -2548,6 +2802,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2879,6 +3143,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -3350,6 +3620,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3390,6 +3670,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4814,8 +5103,75 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -4866,6 +5222,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -5426,6 +5788,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5721,6 +6089,37 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { DEFAULT_UI_PARAMS } from './ui/state/types';
 import type { UIParams, UIStrategyParams } from './ui/state/types';
 import type { StrategyId } from './lib/strategies/types';
 import { useSimulation } from './ui/state/useSimulation';
+import { MetricCards, TrajectoryChart } from './ui/results';
 
 function defaultStrategyParams(id: StrategyId): UIStrategyParams {
   switch (id) {
@@ -61,28 +62,29 @@ function App() {
           />
         </aside>
         <section className="results-panel">
-          <h2>Results</h2>
-          {isRunning && <p className="placeholder">Running simulation…</p>}
+          {isRunning && <p className="running-indicator">Running simulation…</p>}
           {!isRunning && result === null && (
-            <p className="placeholder">Simulation results will appear here.</p>
+            <p className="placeholder">Adjust parameters to run a simulation.</p>
           )}
           {!isRunning && result !== null && (
-            <pre className="results-json">{JSON.stringify(
-              {
-                historical: {
-                  periodCount: result.historical.periodCount,
-                  survivalRate: result.historical.survivalRate,
-                  metrics: result.historical.metrics,
-                },
-                monteCarlo: {
-                  pathCount: result.monteCarlo.pathCount,
-                  survivalRate: result.monteCarlo.survivalRate,
-                  metrics: result.monteCarlo.metrics,
-                },
-              },
-              null,
-              2,
-            )}</pre>
+            <>
+              <MetricCards
+                historical={result.historical.metrics}
+                monteCarlo={result.monteCarlo.metrics}
+              />
+              <div className="trajectory-charts">
+                <TrajectoryChart
+                  trajectories={result.historical.trajectories}
+                  horizonYears={params.horizonYears}
+                  title="Historical trajectories"
+                />
+                <TrajectoryChart
+                  trajectories={result.monteCarlo.trajectories}
+                  horizonYears={params.horizonYears}
+                  title="Monte Carlo trajectories"
+                />
+              </div>
+            </>
           )}
         </section>
       </main>

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,236 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 14px;
+  color: #111827;
+  background: #f3f4f6;
+}
+
+/* ─── App shell ──────────────────────────────────────────────────────────────── */
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  background: #1e40af;
+  color: white;
+  padding: 0.75rem 1.25rem;
+  flex-shrink: 0;
+}
+
+.app-header h1 {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.app-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  height: calc(100vh - 44px);
+}
+
+/* ─── Controls panel ─────────────────────────────────────────────────────────── */
+
+.controls-panel {
+  width: 272px;
+  flex-shrink: 0;
+  border-right: 1px solid #e5e7eb;
+  padding: 1rem;
+  overflow-y: auto;
+  background: #f9fafb;
+}
+
+.controls-panel h2 {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b7280;
+  margin-bottom: 0.875rem;
+}
+
+.control-group {
+  margin-bottom: 1rem;
+}
+
+.control-group label {
+  display: block;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 0.3rem;
+}
+
+.control-group input[type='range'] {
+  width: 100%;
+  accent-color: #3b82f6;
+}
+
+.control-group input[type='number'],
+.control-group select {
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  background: white;
+}
+
+.allocation-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: #374151;
+}
+
+.allocation-row input {
+  flex: 1;
+}
+
+/* ─── Results panel ──────────────────────────────────────────────────────────── */
+
+.results-panel {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-width: 0;
+}
+
+.results-panel h2 {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b7280;
+}
+
+.placeholder {
+  color: #9ca3af;
+  font-size: 0.875rem;
+  font-style: italic;
+}
+
+.running-indicator {
+  color: #6b7280;
+  font-size: 0.875rem;
+  font-style: italic;
+}
+
+/* ─── Metric cards ───────────────────────────────────────────────────────────── */
+
+.metric-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.metric-section-title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b7280;
+  margin-bottom: 0.5rem;
+}
+
+.metric-cards-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(148px, 1fr));
+  gap: 0.625rem;
+}
+
+.metric-card {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 0.875rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.metric-label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #9ca3af;
+}
+
+.metric-value {
+  font-size: 1.3125rem;
+  font-weight: 700;
+  color: #111827;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
+/* ─── Trajectory charts ──────────────────────────────────────────────────────── */
+
+.trajectory-charts {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.trajectory-chart {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 1rem 0.75rem 0.75rem;
+}
+
+.chart-title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b7280;
+  margin-bottom: 0.5rem;
+  padding-left: 0.25rem;
+}
+
+.chart-empty {
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #9ca3af;
+  font-size: 0.875rem;
+  font-style: italic;
+}
+
+.chart-tooltip {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8125rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.chart-tooltip-year {
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 0.25rem;
+}
+
+.chart-tooltip p {
+  color: #6b7280;
+  line-height: 1.5;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import './index.css'
 import App from './App.tsx'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/src/ui/results/MetricCards.test.tsx
+++ b/src/ui/results/MetricCards.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { formatDollars, formatPct, MetricCards } from './MetricCards';
+import type { AggregateMetrics } from '../../lib/metrics/aggregate';
+
+// ─── formatDollars ────────────────────────────────────────────────────────────
+
+describe('formatDollars', () => {
+  it('formats millions with two decimal places', () => {
+    expect(formatDollars(1_500_000)).toBe('$1.50M');
+    expect(formatDollars(2_340_000)).toBe('$2.34M');
+  });
+
+  it('formats exact millions without rounding artifacts', () => {
+    expect(formatDollars(1_000_000)).toBe('$1.00M');
+  });
+
+  it('formats thousands with no decimal places', () => {
+    expect(formatDollars(750_000)).toBe('$750K');
+    expect(formatDollars(1_000)).toBe('$1K');
+  });
+
+  it('formats sub-thousand values as whole dollars', () => {
+    expect(formatDollars(500)).toBe('$500');
+    expect(formatDollars(0)).toBe('$0');
+  });
+
+  it('handles negative values correctly', () => {
+    expect(formatDollars(-1_200_000)).toBe('$-1.20M');
+    expect(formatDollars(-500_000)).toBe('$-500K');
+  });
+});
+
+// ─── formatPct ────────────────────────────────────────────────────────────────
+
+describe('formatPct', () => {
+  it('formats a fraction as a percentage with one decimal', () => {
+    expect(formatPct(0.735)).toBe('73.5%');
+    expect(formatPct(1)).toBe('100.0%');
+    expect(formatPct(0)).toBe('0.0%');
+  });
+
+  it('rounds to one decimal place', () => {
+    expect(formatPct(0.3333)).toBe('33.3%');
+    expect(formatPct(0.6667)).toBe('66.7%');
+  });
+});
+
+// ─── MetricCards rendering ────────────────────────────────────────────────────
+
+function makeMetrics(overrides: Partial<AggregateMetrics> = {}): AggregateMetrics {
+  return {
+    trajectoryCount: 100,
+    survivalRate: 0.85,
+    endingRealValue: { mean: 1_200_000, median: 1_050_000, p10: 400_000, p25: 700_000, p75: 1_500_000, p90: 2_000_000 },
+    realWithdrawal: { mean: 42_000, median: 40_000, variance: 0 },
+    failureYearDistribution: {},
+    meanMaxDrawdown: 0.32,
+    medianMaxDrawdown: 0.28,
+    ...overrides,
+  };
+}
+
+describe('MetricCards', () => {
+  it('renders section headings for historical and monte carlo', () => {
+    render(<MetricCards historical={makeMetrics()} monteCarlo={makeMetrics()} />);
+    expect(screen.getByText('Historical')).toBeDefined();
+    expect(screen.getByText('Monte Carlo')).toBeDefined();
+  });
+
+  it('renders formatted survival rate', () => {
+    render(<MetricCards historical={makeMetrics({ survivalRate: 0.734 })} monteCarlo={makeMetrics()} />);
+    expect(screen.getAllByText('73.4%').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders formatted median ending value in millions', () => {
+    render(<MetricCards historical={makeMetrics()} monteCarlo={makeMetrics()} />);
+    // median is 1_050_000 → $1.05M
+    expect(screen.getAllByText('$1.05M').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders mean annual withdrawal', () => {
+    render(<MetricCards historical={makeMetrics()} monteCarlo={makeMetrics()} />);
+    // mean withdrawal 42_000 → $42K
+    expect(screen.getAllByText('$42K').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders median max drawdown as percentage', () => {
+    render(<MetricCards historical={makeMetrics()} monteCarlo={makeMetrics()} />);
+    // medianMaxDrawdown 0.28 → 28.0%
+    expect(screen.getAllByText('28.0%').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows zeroed values when metrics are empty (survival rate 0)', () => {
+    const empty = makeMetrics({
+      survivalRate: 0,
+      endingRealValue: { mean: 0, median: 0, p10: 0, p25: 0, p75: 0, p90: 0 },
+      realWithdrawal: { mean: 0, median: 0, variance: 0 },
+      medianMaxDrawdown: 0,
+    });
+    render(<MetricCards historical={empty} monteCarlo={empty} />);
+    expect(screen.getAllByText('0.0%').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/ui/results/MetricCards.tsx
+++ b/src/ui/results/MetricCards.tsx
@@ -1,0 +1,68 @@
+import type { AggregateMetrics } from '../../lib/metrics/aggregate';
+
+export function formatDollars(v: number): string {
+  const abs = Math.abs(v);
+  if (abs >= 1_000_000) return `$${(v / 1_000_000).toFixed(2)}M`;
+  if (abs >= 1_000) return `$${(v / 1_000).toFixed(0)}K`;
+  return `$${v.toFixed(0)}`;
+}
+
+export function formatPct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+interface MetricCardProps {
+  label: string;
+  value: string;
+}
+
+function MetricCard({ label, value }: MetricCardProps) {
+  return (
+    <div className="metric-card">
+      <span className="metric-label">{label}</span>
+      <span className="metric-value">{value}</span>
+    </div>
+  );
+}
+
+interface MetricSectionProps {
+  title: string;
+  metrics: AggregateMetrics;
+}
+
+function MetricSection({ title, metrics }: MetricSectionProps) {
+  return (
+    <div className="metric-section">
+      <h3 className="metric-section-title">{title}</h3>
+      <div className="metric-cards-row">
+        <MetricCard label="Survival Rate" value={formatPct(metrics.survivalRate)} />
+        <MetricCard
+          label="Median Ending Value"
+          value={formatDollars(metrics.endingRealValue.median)}
+        />
+        <MetricCard
+          label="Mean Annual Withdrawal"
+          value={formatDollars(metrics.realWithdrawal.mean)}
+        />
+        <MetricCard
+          label="Median Max Drawdown"
+          value={formatPct(metrics.medianMaxDrawdown)}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface MetricCardsProps {
+  historical: AggregateMetrics;
+  monteCarlo: AggregateMetrics;
+}
+
+export function MetricCards({ historical, monteCarlo }: MetricCardsProps) {
+  return (
+    <div className="metric-cards">
+      <MetricSection title="Historical" metrics={historical} />
+      <MetricSection title="Monte Carlo" metrics={monteCarlo} />
+    </div>
+  );
+}

--- a/src/ui/results/TrajectoryChart.tsx
+++ b/src/ui/results/TrajectoryChart.tsx
@@ -1,0 +1,174 @@
+import { useMemo } from 'react';
+import {
+  ResponsiveContainer,
+  ComposedChart,
+  Area,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from 'recharts';
+import type { TooltipContentProps } from 'recharts';
+import type { Trajectory } from '../../lib/simulation/types';
+import { formatDollars } from './MetricCards';
+
+const SAMPLE_COUNT = 50;
+const BAND_COLOR = '#3b82f6';
+const PATH_COLOR = '#93c5fd';
+const MEDIAN_COLOR = '#1d4ed8';
+
+function percentileOf(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+  const idx = p * (sorted.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+function sampleEvenly<T>(arr: T[], maxCount: number): T[] {
+  if (arr.length <= maxCount) return arr;
+  const step = arr.length / maxCount;
+  return Array.from({ length: maxCount }, (_, i) => arr[Math.floor(i * step)]);
+}
+
+interface ChartPoint {
+  year: number;
+  p10: number;
+  band: number;
+  p50: number;
+  [key: string]: number;
+}
+
+function buildChartData(
+  trajectories: Trajectory[],
+  horizonYears: number,
+): { data: ChartPoint[]; pathKeys: string[] } {
+  const sampled = sampleEvenly(trajectories, SAMPLE_COUNT);
+  const pathKeys = sampled.map((_, i) => `path_${i}`);
+
+  const data: ChartPoint[] = Array.from({ length: horizonYears }, (_, y) => {
+    const monthIdx = (y + 1) * 12 - 1;
+    const allBalances = trajectories
+      .map((t) => t.realBalance[monthIdx] ?? 0)
+      .sort((a, b) => a - b);
+    const p10 = percentileOf(allBalances, 0.1);
+    const p50 = percentileOf(allBalances, 0.5);
+    const p90 = percentileOf(allBalances, 0.9);
+
+    const point: ChartPoint = { year: y + 1, p10, band: p90 - p10, p50 };
+    sampled.forEach((t, i) => {
+      point[`path_${i}`] = t.realBalance[monthIdx] ?? 0;
+    });
+    return point;
+  });
+
+  return { data, pathKeys };
+}
+
+function BandTooltip({ active, payload, label }: TooltipContentProps) {
+  if (!active || !payload || payload.length === 0) return null;
+
+  const p10 = payload.find((p) => p.dataKey === 'p10')?.value ?? 0;
+  const band = payload.find((p) => p.dataKey === 'band')?.value ?? 0;
+  const p50 = payload.find((p) => p.dataKey === 'p50')?.value ?? 0;
+  const p90 = (p10 as number) + (band as number);
+
+  return (
+    <div className="chart-tooltip">
+      <p className="chart-tooltip-year">Year {label}</p>
+      <p>P90: {formatDollars(p90 as number)}</p>
+      <p>Median: {formatDollars(p50 as number)}</p>
+      <p>P10: {formatDollars(p10 as number)}</p>
+    </div>
+  );
+}
+
+interface TrajectoryChartProps {
+  trajectories: Trajectory[];
+  horizonYears: number;
+  title: string;
+}
+
+export function TrajectoryChart({ trajectories, horizonYears, title }: TrajectoryChartProps) {
+  const { data, pathKeys } = useMemo(
+    () =>
+      trajectories.length > 0
+        ? buildChartData(trajectories, horizonYears)
+        : { data: [], pathKeys: [] },
+    [trajectories, horizonYears],
+  );
+
+  return (
+    <div className="trajectory-chart">
+      <h3 className="chart-title">{title}</h3>
+      {trajectories.length === 0 ? (
+        <div className="chart-empty">No trajectory data available.</div>
+      ) : (
+        <ResponsiveContainer width="100%" height={300}>
+          <ComposedChart data={data} margin={{ top: 8, right: 16, bottom: 24, left: 16 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+            <XAxis
+              dataKey="year"
+              label={{ value: 'Year', position: 'insideBottom', offset: -8 }}
+              tick={{ fontSize: 12 }}
+            />
+            <YAxis
+              tickFormatter={(v: number) => formatDollars(v)}
+              tick={{ fontSize: 11 }}
+              width={72}
+            />
+            <Tooltip content={BandTooltip} />
+
+            {/* Stacked band: transparent base (p10) + visible top (p90−p10) */}
+            <Area
+              type="monotone"
+              dataKey="p10"
+              fill="transparent"
+              stroke="none"
+              stackId="band"
+              legendType="none"
+              isAnimationActive={false}
+            />
+            <Area
+              type="monotone"
+              dataKey="band"
+              fill={BAND_COLOR}
+              fillOpacity={0.15}
+              stroke="none"
+              stackId="band"
+              name="P10–P90 band"
+              isAnimationActive={false}
+            />
+
+            {/* Sampled paths (thin, low-opacity) */}
+            {pathKeys.map((key) => (
+              <Line
+                key={key}
+                type="monotone"
+                dataKey={key}
+                stroke={PATH_COLOR}
+                strokeWidth={0.75}
+                dot={false}
+                legendType="none"
+                isAnimationActive={false}
+              />
+            ))}
+
+            {/* Median line on top */}
+            <Line
+              type="monotone"
+              dataKey="p50"
+              stroke={MEDIAN_COLOR}
+              strokeWidth={2}
+              dot={false}
+              name="Median (P50)"
+              isAnimationActive={false}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+}

--- a/src/ui/results/index.ts
+++ b/src/ui/results/index.ts
@@ -1,0 +1,2 @@
+export { MetricCards, formatDollars, formatPct } from './MetricCards';
+export { TrajectoryChart } from './TrajectoryChart';

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## What
Replaces the raw JSON debug output with a real Results panel: four summary metric cards per simulation mode (Historical and Monte Carlo) plus a time-series trajectory chart for each, showing up to 50 sampled paths with a shaded P10–P90 percentile band and a bold P50 median line.

## Changes
- `src/ui/results/MetricCards.tsx` — survival rate, median ending value, mean annual withdrawal, and median max drawdown cards, side-by-side for Historical vs Monte Carlo; exports `formatDollars` / `formatPct` for direct unit testing
- `src/ui/results/TrajectoryChart.tsx` — Recharts `ComposedChart` with stacked-Area percentile band (P10–P90, 15 % opacity) + sampled path lines (≤50) + bold P50 median; custom tooltip shows P10/P50/P90 only; all animation disabled for performance
- `src/ui/results/index.ts` — barrel export
- `src/ui/results/MetricCards.test.tsx` — 13 tests: `formatDollars` (millions, thousands, sub-thousand, negative), `formatPct` (rounding), `MetricCards` rendering (labels, real-dollar display, percentages, zero/empty state)
- `src/App.tsx` — wires `MetricCards` + two `TrajectoryChart` instances (historical, Monte Carlo) in place of `<pre>` dump
- `src/index.css` — app layout (two-column shell, controls panel, results panel) + metric card + chart styles
- `src/main.tsx` — imports `index.css`
- `src/vite-env.d.ts` — Vite client type reference (required for CSS side-effect import)
- `package.json` / `package-lock.json` — adds `recharts@^3.8.1`

**Chart library ADR:** chose Recharts over visx. Recharts is declarative React-first (no raw D3 API), ships Line/Area/ComposedChart covering all trajectory visualization needs, and has ~4.5M weekly downloads with active v3 maintenance. visx would require lower-level D3 integration with no benefit for this use case.

## How to test
1. `npm run dev` → open http://localhost:5173
2. Default params load automatically; wait ~1 s for the simulation worker to complete
3. Verify: four metric cards each for Historical and Monte Carlo (survival rate, median ending value, mean withdrawal, drawdown)
4. Verify: two trajectory charts below — each shows a blue shaded band (P10–P90), thin light-blue paths, and a dark-blue median line
5. Hover over the charts — tooltip shows Year N / P90 / Median / P10 values only
6. Adjust any parameter (horizon, strategy, portfolio) — results re-render within ~150 ms debounce

## Manual steps
- NA

## Test results
- All tests: 145 passing, 0 failing
- New tests: 13 (MetricCards.test.tsx)

## Screenshots
<img width="2672" height="1432" alt="Screenshot 2026-05-02 at 9 03 56 PM" src="https://github.com/user-attachments/assets/0d6030b8-4514-4612-bab8-f56829669677" />

## Out of scope
- Distribution histogram for ending wealth (follow-on issue)
- Failure-year bar chart
- Legend for the trajectory chart
- Responsive / mobile layout

## Checklist
- [x] Tests / types / lint / build all green
- [x] No secrets or env vars in code
- [x] `.env.example` not applicable (no new env vars)
- [x] No debug statements committed
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commits or metadata
- [x] Schema changes have migrations (not applicable — no DB)

Fixes J-20