### PR TITLE
feat(viz): distribution charts + historical/MC compare view

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--", "--open=false"],
+      "port": 3000
+    }
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { DEFAULT_UI_PARAMS } from './ui/state/types';
 import type { UIParams, UIStrategyParams } from './ui/state/types';
 import type { StrategyId } from './lib/strategies/types';
 import { useSimulation } from './ui/state/useSimulation';
-import { MetricCards, TrajectoryChart } from './ui/results';
+import { MetricCards, TrajectoryChart, CompareView } from './ui/results';
 
 function defaultStrategyParams(id: StrategyId): UIStrategyParams {
   switch (id) {
@@ -84,6 +84,11 @@ function App() {
                   title="Monte Carlo trajectories"
                 />
               </div>
+              <CompareView
+                historical={result.historical}
+                monteCarlo={result.monteCarlo}
+                initialPortfolio={params.initialPortfolio}
+              />
             </>
           )}
         </section>

--- a/src/index.css
+++ b/src/index.css
@@ -234,3 +234,37 @@ body {
   color: #6b7280;
   line-height: 1.5;
 }
+
+/* ─── Distribution charts ──────────────────────────────────────────────────── */
+
+.distribution-chart {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+/* ─── CompareView ──────────────────────────────────────────────────────────── */
+
+.compare-view {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.compare-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.compare-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #374151;
+  margin: 0;
+}
+
+.compare-charts-row {
+  display: flex;
+  gap: 1.5rem;
+}

--- a/src/lib/viz/histogram.test.ts
+++ b/src/lib/viz/histogram.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { buildBins, unionDomain } from './histogram';
+
+describe('buildBins', () => {
+  it('returns empty array for empty input', () => {
+    expect(buildBins([])).toEqual([]);
+  });
+
+  it('returns one bin for a single value', () => {
+    const bins = buildBins([42]);
+    expect(bins).toHaveLength(1);
+    expect(bins[0].x0).toBe(42);
+    expect(bins[0].x1).toBe(42);
+    expect(bins[0].count).toBe(1);
+    expect(bins[0].pct).toBe(1);
+  });
+
+  it('returns one bin when all values are identical', () => {
+    const bins = buildBins([5, 5, 5]);
+    expect(bins).toHaveLength(1);
+    expect(bins[0].count).toBe(3);
+    expect(bins[0].pct).toBe(1);
+  });
+
+  it('produces the requested number of bins', () => {
+    const values = Array.from({ length: 100 }, (_, i) => i);
+    expect(buildBins(values, { binCount: 10 })).toHaveLength(10);
+    expect(buildBins(values, { binCount: 5 })).toHaveLength(5);
+  });
+
+  it('counts are non-negative and sum to total values count', () => {
+    const values = [1, 2, 3, 8, 9, 10, 15, 20];
+    const bins = buildBins(values, { binCount: 4 });
+    const total = bins.reduce((s, b) => s + b.count, 0);
+    expect(total).toBe(values.length);
+    for (const bin of bins) {
+      expect(bin.count).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('pct for each bin equals count / total', () => {
+    const values = [10, 20, 30, 40, 50];
+    const bins = buildBins(values, { binCount: 5 });
+    const total = values.length;
+    for (const bin of bins) {
+      expect(bin.pct).toBeCloseTo(bin.count / total, 10);
+    }
+  });
+
+  it('pct values sum to 1', () => {
+    const values = Array.from({ length: 200 }, (_, i) => i * 0.5);
+    const bins = buildBins(values, { binCount: 10 });
+    const totalPct = bins.reduce((s, b) => s + b.pct, 0);
+    expect(totalPct).toBeCloseTo(1, 10);
+  });
+
+  it('places a value equal to domainMax into the last bin', () => {
+    const values = [0, 5, 10];
+    const bins = buildBins(values, { binCount: 2 });
+    const lastBin = bins[bins.length - 1];
+    expect(lastBin.count).toBeGreaterThanOrEqual(1);
+  });
+
+  it('respects domainMin and domainMax overrides for shared-axis use', () => {
+    const bins = buildBins([50, 60, 70], { binCount: 10, domainMin: 0, domainMax: 100 });
+    expect(bins).toHaveLength(10);
+    expect(bins[0].x0).toBe(0);
+    expect(bins[bins.length - 1].x1).toBeCloseTo(100, 5);
+    const total = bins.reduce((s, b) => s + b.count, 0);
+    expect(total).toBe(3);
+  });
+
+  it('values outside [domainMin, domainMax] are excluded when domain is overridden', () => {
+    const bins = buildBins([10, 50, 90], { binCount: 4, domainMin: 20, domainMax: 80 });
+    const total = bins.reduce((s, b) => s + b.count, 0);
+    // 10 and 90 are outside the imposed domain
+    expect(total).toBe(1);
+  });
+
+  it('throws RangeError when binCount < 1', () => {
+    expect(() => buildBins([1, 2, 3], { binCount: 0 })).toThrow(RangeError);
+  });
+
+  it('bin boundaries are contiguous (x1[i] === x0[i+1])', () => {
+    const values = Array.from({ length: 50 }, (_, i) => i * 2);
+    const bins = buildBins(values, { binCount: 10 });
+    for (let i = 0; i < bins.length - 1; i++) {
+      expect(bins[i].x1).toBeCloseTo(bins[i + 1].x0, 10);
+    }
+  });
+});
+
+describe('unionDomain', () => {
+  it('returns [0, 0] for empty input', () => {
+    expect(unionDomain([])).toEqual([0, 0]);
+  });
+
+  it('returns [0, 0] for arrays containing no values', () => {
+    expect(unionDomain([[], []])).toEqual([0, 0]);
+  });
+
+  it('returns the min and max across all arrays', () => {
+    const [min, max] = unionDomain([[10, 20], [5, 15], [30, 8]]);
+    expect(min).toBe(5);
+    expect(max).toBe(30);
+  });
+
+  it('handles a single array', () => {
+    expect(unionDomain([[3, 1, 4, 1, 5, 9]])).toEqual([1, 9]);
+  });
+
+  it('handles negative values', () => {
+    const [min, max] = unionDomain([[-100, 0], [50, -200]]);
+    expect(min).toBe(-200);
+    expect(max).toBe(50);
+  });
+});

--- a/src/lib/viz/histogram.ts
+++ b/src/lib/viz/histogram.ts
@@ -1,0 +1,79 @@
+export interface Bin {
+  /** Inclusive lower bound of the bin. */
+  x0: number;
+  /** Exclusive upper bound of the bin (except the last bin, which is inclusive). */
+  x1: number;
+  /** Number of values that fall in this bin. */
+  count: number;
+  /** Fraction of total values in this bin (0–1). */
+  pct: number;
+}
+
+export interface BinOptions {
+  /** Number of equal-width bins. Must be >= 1. Defaults to 20. */
+  binCount?: number;
+  /** Override the minimum domain value. Useful for shared-axis charts. */
+  domainMin?: number;
+  /** Override the maximum domain value. Useful for shared-axis charts. */
+  domainMax?: number;
+}
+
+/**
+ * Partitions `values` into equal-width bins.
+ *
+ * Returns an empty array when `values` is empty.
+ * When all values are identical, returns a single bin containing all values.
+ */
+export function buildBins(values: number[], options: BinOptions = {}): Bin[] {
+  if (values.length === 0) return [];
+
+  const { binCount = 20 } = options;
+  if (binCount < 1) throw new RangeError('binCount must be >= 1');
+
+  const min = options.domainMin ?? Math.min(...values);
+  const max = options.domainMax ?? Math.max(...values);
+
+  // Degenerate case: all values are identical (or domain collapsed to a point).
+  if (min === max) {
+    return [{ x0: min, x1: max, count: values.length, pct: 1 }];
+  }
+
+  const width = (max - min) / binCount;
+  const bins: Bin[] = Array.from({ length: binCount }, (_, i) => ({
+    x0: min + i * width,
+    x1: min + (i + 1) * width,
+    count: 0,
+    pct: 0,
+  }));
+
+  for (const v of values) {
+    if (v < min || v > max) continue; // exclude out-of-domain values when domain is forced
+    // Values equal to max fall in the last bin via the clamp.
+    const idx = Math.min(Math.floor((v - min) / width), binCount - 1);
+    bins[idx].count++;
+  }
+
+  const total = values.length;
+  for (const bin of bins) {
+    bin.pct = bin.count / total;
+  }
+
+  return bins;
+}
+
+/**
+ * Computes the union domain [min, max] across multiple value arrays.
+ * Useful for aligning axes before passing `domainMin`/`domainMax` to `buildBins`.
+ */
+export function unionDomain(arrays: number[][]): [number, number] {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const arr of arrays) {
+    for (const v of arr) {
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+  }
+  if (!isFinite(min) || !isFinite(max)) return [0, 0];
+  return [min, max];
+}

--- a/src/ui/results/CompareView.test.tsx
+++ b/src/ui/results/CompareView.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CompareView } from './CompareView';
+import { withdrawalYDomain } from './WithdrawalDistribution';
+import { unionDomain } from '../../lib/viz/histogram';
+import type { HistoricalResult } from '../../lib/runners/historical';
+import type { MonteCarloResult } from '../../lib/montecarlo/types';
+
+// ─── Shared-axis helpers ──────────────────────────────────────────────────────
+
+describe('unionDomain for ending wealth', () => {
+  it('spans both historical and MC value ranges', () => {
+    const [min, max] = unionDomain([[100, 500, 900], [200, 1000]]);
+    expect(min).toBe(100);
+    expect(max).toBe(1000);
+  });
+
+  it('handles one set with all zeros', () => {
+    const [min, max] = unionDomain([[0, 0, 0], [500, 1500]]);
+    expect(min).toBe(0);
+    expect(max).toBe(1500);
+  });
+});
+
+describe('withdrawalYDomain', () => {
+  it('returns global min and max across all years and scenarios', () => {
+    const data: number[][] = [
+      [10_000, 20_000, 5_000],
+      [15_000, 40_000, 3_000],
+    ];
+    const [min, max] = withdrawalYDomain(data);
+    expect(min).toBe(3_000);
+    expect(max).toBe(40_000);
+  });
+
+  it('returns [0, 0] for empty input', () => {
+    expect(withdrawalYDomain([])).toEqual([0, 0]);
+  });
+
+  it('returns [0, 0] when all inner arrays are empty', () => {
+    expect(withdrawalYDomain([[], []])).toEqual([0, 0]);
+  });
+});
+
+// ─── CompareView rendering ────────────────────────────────────────────────────
+
+function makeHistorical(overrides: Partial<HistoricalResult> = {}): HistoricalResult {
+  const horizonYears = 3;
+  const periodCount = 5;
+  return {
+    periodCount,
+    survivalRate: 0.8,
+    startDates: ['2000-01', '2001-01', '2002-01', '2003-01', '2004-01'],
+    endingNominalValues: [800_000, 900_000, 1_000_000, 700_000, 1_100_000],
+    endingRealValues: [750_000, 850_000, 950_000, 650_000, 1_050_000],
+    nominalWithdrawalsPerYear: Array.from({ length: horizonYears }, () =>
+      Array.from({ length: periodCount }, () => 40_000),
+    ),
+    realWithdrawalsPerYear: Array.from({ length: horizonYears }, () =>
+      Array.from({ length: periodCount }, () => 38_000),
+    ),
+    trajectories: [],
+    metrics: {
+      trajectoryCount: periodCount,
+      survivalRate: 0.8,
+      endingRealValue: { mean: 850_000, median: 850_000, p10: 650_000, p25: 750_000, p75: 950_000, p90: 1_050_000 },
+      realWithdrawal: { mean: 38_000, median: 38_000, variance: 0 },
+      failureYearDistribution: {},
+      meanMaxDrawdown: 0.1,
+      medianMaxDrawdown: 0.1,
+    },
+    ...overrides,
+  };
+}
+
+function makeMonteCarlo(overrides: Partial<MonteCarloResult> = {}): MonteCarloResult {
+  const horizonYears = 3;
+  const pathCount = 5;
+  return {
+    pathCount,
+    seed: 42,
+    survivalRate: 0.9,
+    endingNominalValues: [900_000, 1_100_000, 1_200_000, 800_000, 1_300_000],
+    endingRealValues: [850_000, 1_050_000, 1_150_000, 750_000, 1_250_000],
+    nominalWithdrawalsPerYear: Array.from({ length: horizonYears }, () =>
+      Array.from({ length: pathCount }, () => 42_000),
+    ),
+    realWithdrawalsPerYear: Array.from({ length: horizonYears }, () =>
+      Array.from({ length: pathCount }, () => 40_000),
+    ),
+    trajectories: [],
+    metrics: {
+      trajectoryCount: pathCount,
+      survivalRate: 0.9,
+      endingRealValue: { mean: 1_010_000, median: 1_050_000, p10: 750_000, p25: 850_000, p75: 1_150_000, p90: 1_250_000 },
+      realWithdrawal: { mean: 40_000, median: 40_000, variance: 0 },
+      failureYearDistribution: {},
+      meanMaxDrawdown: 0.08,
+      medianMaxDrawdown: 0.08,
+    },
+    ...overrides,
+  };
+}
+
+describe('CompareView', () => {
+  it('renders section headings for both chart types', () => {
+    render(<CompareView historical={makeHistorical()} monteCarlo={makeMonteCarlo()} />);
+    expect(screen.getByText('Ending Wealth Distribution')).toBeTruthy();
+    expect(screen.getByText(/Annual Withdrawal/)).toBeTruthy();
+  });
+
+  it('renders four chart titles: Historical and Monte Carlo for each section', () => {
+    render(<CompareView historical={makeHistorical()} monteCarlo={makeMonteCarlo()} />);
+    const historicalTitles = screen.getAllByText('Historical');
+    const mcTitles = screen.getAllByText('Monte Carlo');
+    expect(historicalTitles.length).toBeGreaterThanOrEqual(2);
+    expect(mcTitles.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders empty-state gracefully when both datasets have no values', () => {
+    const emptyHistorical = makeHistorical({ endingRealValues: [], realWithdrawalsPerYear: [] });
+    const emptyMC = makeMonteCarlo({ endingRealValues: [], realWithdrawalsPerYear: [] });
+    render(<CompareView historical={emptyHistorical} monteCarlo={emptyMC} />);
+    const emptyMessages = screen.getAllByText('No data available.');
+    expect(emptyMessages.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/ui/results/CompareView.tsx
+++ b/src/ui/results/CompareView.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from 'react';
+import type { HistoricalResult } from '../../lib/runners/historical';
+import type { MonteCarloResult } from '../../lib/montecarlo/types';
+import { unionDomain } from '../../lib/viz/histogram';
+import { EndingWealthDistribution } from './EndingWealthDistribution';
+import { WithdrawalDistribution, withdrawalYDomain } from './WithdrawalDistribution';
+
+/** Merges two [yearIndex][scenarioIndex] arrays into one. */
+function mergeWithdrawals(a: number[][], b: number[][]): number[][] {
+  const years = Math.max(a.length, b.length);
+  return Array.from({ length: years }, (_, y) => [
+    ...(a[y] ?? []),
+    ...(b[y] ?? []),
+  ]);
+}
+
+interface CompareViewProps {
+  historical: HistoricalResult;
+  monteCarlo: MonteCarloResult;
+  /** Starting portfolio value used as a reference line on the wealth histogram. */
+  initialPortfolio?: number;
+}
+
+export function CompareView({ historical, monteCarlo, initialPortfolio }: CompareViewProps) {
+  const wealthDomain = useMemo(
+    () =>
+      unionDomain([historical.endingRealValues, monteCarlo.endingRealValues]) as [number, number],
+    [historical.endingRealValues, monteCarlo.endingRealValues],
+  );
+
+  const withdrawalDomain = useMemo(() => {
+    const merged = mergeWithdrawals(
+      historical.realWithdrawalsPerYear,
+      monteCarlo.realWithdrawalsPerYear,
+    );
+    return withdrawalYDomain(merged);
+  }, [historical.realWithdrawalsPerYear, monteCarlo.realWithdrawalsPerYear]);
+
+  return (
+    <div className="compare-view">
+      <section className="compare-section">
+        <h3 className="compare-section-title">Ending Wealth Distribution</h3>
+        <div className="compare-charts-row">
+          <EndingWealthDistribution
+            endingRealValues={historical.endingRealValues}
+            domain={wealthDomain}
+            referenceValue={initialPortfolio}
+            color="#3b82f6"
+            title="Historical"
+          />
+          <EndingWealthDistribution
+            endingRealValues={monteCarlo.endingRealValues}
+            domain={wealthDomain}
+            referenceValue={initialPortfolio}
+            color="#22c55e"
+            title="Monte Carlo"
+          />
+        </div>
+      </section>
+
+      <section className="compare-section">
+        <h3 className="compare-section-title">Annual Withdrawal (Real, P10–P90 Band)</h3>
+        <div className="compare-charts-row">
+          <WithdrawalDistribution
+            realWithdrawalsPerYear={historical.realWithdrawalsPerYear}
+            yDomain={withdrawalDomain}
+            color="#3b82f6"
+            title="Historical"
+          />
+          <WithdrawalDistribution
+            realWithdrawalsPerYear={monteCarlo.realWithdrawalsPerYear}
+            yDomain={withdrawalDomain}
+            color="#22c55e"
+            title="Monte Carlo"
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/ui/results/EndingWealthDistribution.tsx
+++ b/src/ui/results/EndingWealthDistribution.tsx
@@ -1,0 +1,105 @@
+import { useMemo } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from 'recharts';
+import type { TooltipContentProps } from 'recharts';
+import { buildBins } from '../../lib/viz/histogram';
+import { formatDollars } from './MetricCards';
+
+const BIN_COUNT = 30;
+
+interface BarTooltipProps extends TooltipContentProps {
+  binWidth: number;
+}
+
+function BarTooltip({ active, payload, binWidth }: BarTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  const { x0, count, pct } = payload[0].payload as {
+    x0: number;
+    count: number;
+    pct: number;
+  };
+  return (
+    <div className="chart-tooltip">
+      <p className="chart-tooltip-year">
+        {formatDollars(x0)} – {formatDollars(x0 + binWidth)}
+      </p>
+      <p>{count} scenarios</p>
+      <p>{(pct * 100).toFixed(1)}%</p>
+    </div>
+  );
+}
+
+interface EndingWealthDistributionProps {
+  endingRealValues: number[];
+  /** Shared x-axis domain [min, max] for aligned comparisons. */
+  domain?: [number, number];
+  /** Vertical line marking a specific value (e.g. starting portfolio). */
+  referenceValue?: number;
+  color?: string;
+  title: string;
+}
+
+export function EndingWealthDistribution({
+  endingRealValues,
+  domain,
+  referenceValue,
+  color = '#3b82f6',
+  title,
+}: EndingWealthDistributionProps) {
+  const { bins, binWidth } = useMemo(() => {
+    const opts = domain ? { binCount: BIN_COUNT, domainMin: domain[0], domainMax: domain[1] } : { binCount: BIN_COUNT };
+    const b = buildBins(endingRealValues, opts);
+    const width = b.length >= 2 ? b[1].x0 - b[0].x0 : 0;
+    return { bins: b, binWidth: width };
+  }, [endingRealValues, domain]);
+
+  const chartData = bins.map((bin) => ({ ...bin, label: formatDollars(bin.x0) }));
+
+  const xMin = domain ? domain[0] : (bins[0]?.x0 ?? 0);
+  const xMax = domain ? domain[1] : (bins[bins.length - 1]?.x1 ?? 0);
+
+  return (
+    <div className="distribution-chart">
+      <h4 className="chart-title">{title}</h4>
+      {endingRealValues.length === 0 ? (
+        <div className="chart-empty">No data available.</div>
+      ) : (
+        <ResponsiveContainer width="100%" height={220}>
+          <BarChart
+            data={chartData}
+            margin={{ top: 8, right: 16, bottom: 28, left: 16 }}
+            barCategoryGap={0}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" vertical={false} />
+            <XAxis
+              dataKey="x0"
+              type="number"
+              domain={[xMin, xMax]}
+              tickFormatter={(v: number) => formatDollars(v)}
+              tick={{ fontSize: 10 }}
+              label={{ value: 'Ending Real Value', position: 'insideBottom', offset: -12, fontSize: 11 }}
+            />
+            <YAxis
+              tickFormatter={(v: number) => `${(v * 100).toFixed(0)}%`}
+              tick={{ fontSize: 10 }}
+              width={40}
+            />
+            <Tooltip content={(props) => <BarTooltip {...props} binWidth={binWidth} />} />
+            {referenceValue !== undefined && (
+              <ReferenceLine x={referenceValue} stroke="#ef4444" strokeDasharray="4 2" strokeWidth={1.5} />
+            )}
+            <Bar dataKey="pct" fill={color} fillOpacity={0.75} isAnimationActive={false} />
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+}

--- a/src/ui/results/WithdrawalDistribution.tsx
+++ b/src/ui/results/WithdrawalDistribution.tsx
@@ -1,0 +1,149 @@
+import { useMemo } from 'react';
+import {
+  ComposedChart,
+  Area,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import type { TooltipContentProps } from 'recharts';
+import { formatDollars } from './MetricCards';
+
+function percentileOf(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+  const idx = p * (sorted.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+interface YearPoint {
+  year: number;
+  p10: number;
+  band: number;
+  p50: number;
+}
+
+function buildWithdrawalBands(realWithdrawalsPerYear: number[][]): YearPoint[] {
+  return realWithdrawalsPerYear.map((yearWithdrawals, yearIdx) => {
+    const sorted = [...yearWithdrawals].sort((a, b) => a - b);
+    const p10 = percentileOf(sorted, 0.1);
+    const p50 = percentileOf(sorted, 0.5);
+    const p90 = percentileOf(sorted, 0.9);
+    return { year: yearIdx + 1, p10, band: p90 - p10, p50 };
+  });
+}
+
+function BandTooltip({ active, payload, label }: TooltipContentProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  const p10 = payload.find((p) => p.dataKey === 'p10')?.value as number ?? 0;
+  const band = payload.find((p) => p.dataKey === 'band')?.value as number ?? 0;
+  const p50 = payload.find((p) => p.dataKey === 'p50')?.value as number ?? 0;
+  const p90 = p10 + band;
+  return (
+    <div className="chart-tooltip">
+      <p className="chart-tooltip-year">Year {label}</p>
+      <p>P90: {formatDollars(p90)}</p>
+      <p>Median: {formatDollars(p50)}</p>
+      <p>P10: {formatDollars(p10)}</p>
+    </div>
+  );
+}
+
+interface WithdrawalDistributionProps {
+  /** realWithdrawalsPerYear[yearIndex][scenarioIndex] */
+  realWithdrawalsPerYear: number[][];
+  /** Shared y-axis domain [min, max] for aligned comparisons. */
+  yDomain?: [number, number];
+  color?: string;
+  title: string;
+}
+
+export function WithdrawalDistribution({
+  realWithdrawalsPerYear,
+  yDomain,
+  color = '#3b82f6',
+  title,
+}: WithdrawalDistributionProps) {
+  const data = useMemo(() => buildWithdrawalBands(realWithdrawalsPerYear), [realWithdrawalsPerYear]);
+  const medianColor = color === '#3b82f6' ? '#1d4ed8' : '#15803d';
+
+  const yMin = yDomain?.[0] ?? 'auto';
+  const yMax = yDomain?.[1] ?? 'auto';
+
+  return (
+    <div className="distribution-chart">
+      <h4 className="chart-title">{title}</h4>
+      {data.length === 0 ? (
+        <div className="chart-empty">No data available.</div>
+      ) : (
+        <ResponsiveContainer width="100%" height={220}>
+          <ComposedChart data={data} margin={{ top: 8, right: 16, bottom: 28, left: 16 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+            <XAxis
+              dataKey="year"
+              tick={{ fontSize: 10 }}
+              label={{ value: 'Year', position: 'insideBottom', offset: -12, fontSize: 11 }}
+            />
+            <YAxis
+              tickFormatter={(v: number) => formatDollars(v)}
+              tick={{ fontSize: 10 }}
+              width={60}
+              domain={[yMin, yMax]}
+            />
+            <Tooltip content={BandTooltip} />
+
+            {/* Transparent base (p10) + visible P10–P90 band */}
+            <Area
+              type="monotone"
+              dataKey="p10"
+              fill="transparent"
+              stroke="none"
+              stackId="band"
+              legendType="none"
+              isAnimationActive={false}
+            />
+            <Area
+              type="monotone"
+              dataKey="band"
+              fill={color}
+              fillOpacity={0.2}
+              stroke="none"
+              stackId="band"
+              name="P10–P90 band"
+              isAnimationActive={false}
+            />
+
+            <Line
+              type="monotone"
+              dataKey="p50"
+              stroke={medianColor}
+              strokeWidth={2}
+              dot={false}
+              name="Median (P50)"
+              isAnimationActive={false}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+}
+
+/** Exported so CompareView can derive a shared y-domain without duplicating logic. */
+export function withdrawalYDomain(realWithdrawalsPerYear: number[][]): [number, number] {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const year of realWithdrawalsPerYear) {
+    for (const v of year) {
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+  }
+  if (!isFinite(min)) return [0, 0];
+  return [min, max];
+}

--- a/src/ui/results/index.ts
+++ b/src/ui/results/index.ts
@@ -1,2 +1,5 @@
 export { MetricCards, formatDollars, formatPct } from './MetricCards';
 export { TrajectoryChart } from './TrajectoryChart';
+export { EndingWealthDistribution } from './EndingWealthDistribution';
+export { WithdrawalDistribution, withdrawalYDomain } from './WithdrawalDistribution';
+export { CompareView } from './CompareView';


### PR DESCRIPTION
## What
Adds ending-wealth histograms, per-year withdrawal variance bands, and an explicit historical-vs-Monte Carlo compare view with shared axes across both chart types. Implements Linear issue J-21.

## Changes
- `src/lib/viz/histogram.ts` — pure `buildBins()` (equal-width binning, optional forced domain) and `unionDomain()` helpers; no React dependencies
- `src/lib/viz/histogram.test.ts` — 17 unit tests: happy path, edge cases (empty, single value, all-identical), pct sums, boundary placement, domain exclusion, `unionDomain`
- `src/ui/results/EndingWealthDistribution.tsx` — recharts BarChart histogram; accepts `domain` prop for shared x-axis and optional `referenceValue` red line
- `src/ui/results/WithdrawalDistribution.tsx` — per-year P10/P50/P90 stacked-area band chart; exports `withdrawalYDomain` helper for shared y-axis
- `src/ui/results/CompareView.tsx` — computes union domains across historical and MC data, then renders both chart types side-by-side with aligned axes
- `src/ui/results/CompareView.test.tsx` — 8 tests: axis-sharing helper behavior, section headings, titles, empty-state rendering
- `src/ui/results/index.ts` — exports the three new components
- `src/App.tsx` — wires `CompareView` below the trajectory charts
- `src/index.css` — layout classes for `.compare-view`, `.compare-section`, `.compare-charts-row`, `.distribution-chart`
- `.claude/launch.json` — dev server config for preview tool

## How to test
1. `npm run dev`
2. Scroll below the trajectory charts
3. Verify "Ending Wealth Distribution" section shows two histograms (blue historical, green MC) on a shared x-axis with a red dashed line at the initial portfolio value
4. Verify "Annual Withdrawal" section shows two P10–P90 band charts on a shared y-axis
5. Change the withdrawal rate slider — both charts in each section should update with the same domain

## Manual steps
- None

## Test results
- All tests: 170 passing, 0 failing
- New tests: 17 (histogram unit) + 8 (CompareView component) = 25 new

## Screenshots
<img width="2672" height="1432" alt="Screenshot 2026-05-02 at 9 14 06 PM" src="https://github.com/user-attachments/assets/7bf83a8c-78eb-4054-a8b5-96e02274a33e" />

## Out of scope
- Overlay mode (both distributions on a single chart with opacity) — can be added later
- Failure-year distribution chart (tracked separately)

## Checklist
- [x] Tests / types / lint / build all green
- [x] No secrets or env vars in code
- [x] `.env.example` updated if new env vars — N/A
- [x] No debug statements committed
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commits or metadata
- [x] Schema changes have migrations — N/A

Fixes J-21